### PR TITLE
Add rector configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1",
         "phpstan/phpstan-strict-rules": "^1",
-        "phpstan/phpstan-symfony": "^1.1"
+        "phpstan/phpstan-symfony": "^1.1",
+        "rector/rector": "^0.12.16"
     },
     "suggest": {
         "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03b82664ef6f80651118f0c06a49280c",
+    "content-hash": "b5d6ca11a8c0c973df13f0a33b5cc2ed",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2115,6 +2115,66 @@
             "time": "2022-02-05T13:48:27+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "0.12.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "13412efd0dfda2e2c310dd24397281804441cf7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/13412efd0dfda2e2c310dd24397281804441cf7a",
+                "reference": "13412efd0dfda2e2c310dd24397281804441cf7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0",
+                "phpstan/phpstan": "^1.4.2"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.2",
+                "rector/rector-cakephp": "*",
+                "rector/rector-doctrine": "*",
+                "rector/rector-laravel": "*",
+                "rector/rector-nette": "*",
+                "rector/rector-phpoffice": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-prefixed": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.12.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-09T14:50:55+00:00"
+        },
+        {
             "name": "symfony/phpunit-bridge",
             "version": "v6.0.3",
             "source": {
@@ -2210,5 +2270,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/rector.php
+++ b/rector.php
@@ -3,10 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
-use Rector\Core\ValueObject\PhpVersion;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
-use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector;
+use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -17,12 +20,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan/config.neon');
 
     // basic rules
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    // $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     $parameters->set(Option::IMPORT_DOC_BLOCKS, true);
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
 
-    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
-    $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(SymfonyLevelSetList::UP_TO_SYMFONY_54);
+    $services->set(AddClosureReturnTypeRector::class);
+    $services->set(AddReturnTypeDeclarationRector::class);
+    $services->set(AddVoidReturnTypeWhereNoReturnRector::class);
+    $services->set(ReturnTypeDeclarationRector::class);
+    $services->set(ReturnTypeFromReturnNewRector::class);
+    $services->set(ReturnTypeFromStrictTypedCallRector::class);
+    $services->set(ReturnTypeFromStrictTypedPropertyRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $services = $containerConfigurator->services();
+
+    $parameters->set(Option::PATHS, [__DIR__ . '/src']);
+    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan/config.neon');
+
+    // basic rules
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    $parameters->set(Option::IMPORT_DOC_BLOCKS, true);
+    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
+    $containerConfigurator->import(SetList::CODE_QUALITY);
+    $containerConfigurator->import(SymfonyLevelSetList::UP_TO_SYMFONY_54);
+};

--- a/rector.php
+++ b/rector.php
@@ -27,8 +27,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(AddClosureReturnTypeRector::class);
     $services->set(AddReturnTypeDeclarationRector::class);
     $services->set(AddVoidReturnTypeWhereNoReturnRector::class);
-    $services->set(ReturnTypeDeclarationRector::class);
     $services->set(ReturnTypeFromReturnNewRector::class);
     $services->set(ReturnTypeFromStrictTypedCallRector::class);
     $services->set(ReturnTypeFromStrictTypedPropertyRector::class);
+
+    // $services->set(ReturnTypeDeclarationRector::class); // would change phpdocs
 };

--- a/src/Composer/Autoload/AutoloadGenerator.php
+++ b/src/Composer/Autoload/AutoloadGenerator.php
@@ -89,7 +89,7 @@ class AutoloadGenerator
      * @param bool $devMode
      * @return void
      */
-    public function setDevMode($devMode = true)
+    public function setDevMode($devMode = true): void
     {
         $this->devMode = (bool) $devMode;
     }
@@ -100,7 +100,7 @@ class AutoloadGenerator
      * @param bool $classMapAuthoritative
      * @return void
      */
-    public function setClassMapAuthoritative($classMapAuthoritative)
+    public function setClassMapAuthoritative($classMapAuthoritative): void
     {
         $this->classMapAuthoritative = (bool) $classMapAuthoritative;
     }
@@ -112,7 +112,7 @@ class AutoloadGenerator
      * @param string|null $apcuPrefix
      * @return void
      */
-    public function setApcu($apcu, $apcuPrefix = null)
+    public function setApcu($apcu, $apcuPrefix = null): void
     {
         $this->apcu = (bool) $apcu;
         $this->apcuPrefix = $apcuPrefix !== null ? (string) $apcuPrefix : $apcuPrefix;
@@ -124,7 +124,7 @@ class AutoloadGenerator
      * @param bool $runScripts
      * @return void
      */
-    public function setRunScripts($runScripts = true)
+    public function setRunScripts($runScripts = true): void
     {
         $this->runScripts = (bool) $runScripts;
     }
@@ -141,7 +141,7 @@ class AutoloadGenerator
      *
      * @deprecated use setPlatformRequirementFilter instead
      */
-    public function setIgnorePlatformRequirements($ignorePlatformReqs)
+    public function setIgnorePlatformRequirements($ignorePlatformReqs): void
     {
         trigger_error('AutoloadGenerator::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead.', E_USER_DEPRECATED);
 
@@ -151,7 +151,7 @@ class AutoloadGenerator
     /**
      * @return void
      */
-    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter)
+    public function setPlatformRequirementFilter(PlatformRequirementFilterInterface $platformRequirementFilter): void
     {
         $this->platformRequirementFilter = $platformRequirementFilter;
     }
@@ -163,7 +163,7 @@ class AutoloadGenerator
      * @return int
      * @throws \Seld\JsonLint\ParsingException
      */
-    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, $targetDir, $scanPsrPackages = false, $suffix = '')
+    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, $targetDir, $scanPsrPackages = false, $suffix = ''): int
     {
         if ($this->classMapAuthoritative) {
             // Force scanPsrPackages when classmap is authoritative
@@ -290,7 +290,7 @@ EOF;
         $mainAutoload = $rootPackage->getAutoload();
         if ($rootPackage->getTargetDir() && !empty($mainAutoload['psr-0'])) {
             $levels = substr_count($filesystem->normalizePath($rootPackage->getTargetDir()), '/') + 1;
-            $prefixes = implode(', ', array_map(function ($prefix) {
+            $prefixes = implode(', ', array_map(function ($prefix): string {
                 return var_export($prefix, true);
             }, array_keys($mainAutoload['psr-0'])));
             $baseDirFromTargetDirCode = $filesystem->findShortestPathCode($targetDir, $basePath, true);
@@ -554,7 +554,7 @@ EOF;
     {
         $rootPackageMap = array_shift($packageMap);
         if (is_array($filteredDevPackages)) {
-            $packageMap = array_filter($packageMap, function ($item) use ($filteredDevPackages) {
+            $packageMap = array_filter($packageMap, function ($item) use ($filteredDevPackages): bool {
                 return !in_array($item[0]->getName(), $filteredDevPackages, true);
             });
         } elseif ($filteredDevPackages) {
@@ -808,7 +808,7 @@ EOF;
 
         ksort($requiredExtensions);
 
-        $formatToPhpVersionId = function (Bound $bound) {
+        $formatToPhpVersionId = function (Bound $bound): int {
             if ($bound->isZero()) {
                 return 0;
             }
@@ -1229,7 +1229,7 @@ INITIALIZER;
                         $updir = null;
                         $path = Preg::replaceCallback(
                             '{^((?:(?:\\\\\\.){1,2}+/)+)}',
-                            function ($matches) use (&$updir) {
+                            function ($matches) use (&$updir): string {
                                 if (isset($matches[1])) {
                                     // undo preg_quote for the matched string
                                     $updir = str_replace('\\.', '.', $matches[1]);
@@ -1300,7 +1300,7 @@ INITIALIZER;
             }
         }
 
-        $add = function (PackageInterface $package) use (&$add, $packages, &$include, $replacedBy) {
+        $add = function (PackageInterface $package) use (&$add, $packages, &$include, $replacedBy): void {
             foreach ($package->getRequires() as $link) {
                 $target = $link->getTarget();
                 if (isset($replacedBy[$target])) {
@@ -1318,7 +1318,7 @@ INITIALIZER;
 
         return array_filter(
             $packageMap,
-            function ($item) use ($include) {
+            function ($item) use ($include): bool {
                 $package = $item[0];
                 foreach ($package->getNames() as $name) {
                     if (isset($include[$name])) {
@@ -1369,7 +1369,7 @@ INITIALIZER;
  * @param string $file
  * @return void
  */
-function composerRequire($fileIdentifier, $file)
+function composerRequire($fileIdentifier, $file): void
 {
     if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
         $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;

--- a/src/Composer/Autoload/ClassLoader.php
+++ b/src/Composer/Autoload/ClassLoader.php
@@ -162,7 +162,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function addClassMap(array $classMap)
+    public function addClassMap(array $classMap): void
     {
         if ($this->classMap) {
             $this->classMap = array_merge($this->classMap, $classMap);
@@ -181,7 +181,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function add($prefix, $paths, $prepend = false)
+    public function add($prefix, $paths, $prepend = false): void
     {
         if (!$prefix) {
             if ($prepend) {
@@ -277,7 +277,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function set($prefix, $paths)
+    public function set($prefix, $paths): void
     {
         if (!$prefix) {
             $this->fallbackDirsPsr0 = (array) $paths;
@@ -318,7 +318,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setUseIncludePath($useIncludePath)
+    public function setUseIncludePath($useIncludePath): void
     {
         $this->useIncludePath = $useIncludePath;
     }
@@ -342,7 +342,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setClassMapAuthoritative($classMapAuthoritative)
+    public function setClassMapAuthoritative($classMapAuthoritative): void
     {
         $this->classMapAuthoritative = $classMapAuthoritative;
     }
@@ -364,7 +364,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function setApcuPrefix($apcuPrefix)
+    public function setApcuPrefix($apcuPrefix): void
     {
         $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
@@ -386,7 +386,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function register($prepend = false)
+    public function register($prepend = false): void
     {
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
 
@@ -407,7 +407,7 @@ class ClassLoader
      *
      * @return void
      */
-    public function unregister()
+    public function unregister(): void
     {
         spl_autoload_unregister(array($this, 'loadClass'));
 
@@ -566,7 +566,7 @@ class ClassLoader
  * @return void
  * @private
  */
-function includeFile($file)
+function includeFile($file): void
 {
     include $file;
 }

--- a/src/Composer/Cache.php
+++ b/src/Composer/Cache.php
@@ -66,7 +66,7 @@ class Cache
      *
      * @return void
      */
-    public function setReadOnly($readOnly)
+    public function setReadOnly($readOnly): void
     {
         $this->readOnly = (bool) $readOnly;
     }
@@ -372,7 +372,7 @@ class Cache
     /**
      * @return Finder
      */
-    protected function getFinder()
+    protected function getFinder(): \Symfony\Component\Finder\Finder
     {
         return Finder::create()->in($this->root)->files();
     }

--- a/src/Composer/Command/ArchiveCommand.php
+++ b/src/Composer/Command/ArchiveCommand.php
@@ -168,7 +168,7 @@ EOT
         if (count($packages) > 1) {
             $package = reset($packages);
             $io->writeError('<info>Found multiple matches, selected '.$package->getPrettyString().'.</info>');
-            $io->writeError('Alternatives were '.implode(', ', array_map(function ($p) {
+            $io->writeError('Alternatives were '.implode(', ', array_map(function ($p): string {
                 return $p->getPrettyString();
             }, $packages)).'.');
             $io->writeError('<comment>Please use a more specific constraint to pick a different package.</comment>');

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -129,7 +129,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setComposer(Composer $composer)
+    public function setComposer(Composer $composer): void
     {
         $this->composer = $composer;
     }
@@ -139,7 +139,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    public function resetComposer()
+    public function resetComposer(): void
     {
         $this->composer = null;
         $this->getApplication()->resetComposer();
@@ -177,7 +177,7 @@ abstract class BaseCommand extends Command
     /**
      * @return void
      */
-    public function setIO(IOInterface $io)
+    public function setIO(IOInterface $io): void
     {
         $this->io = $io;
     }
@@ -187,7 +187,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         // initialize a plugin-enabled Composer instance, either local or global
         $disablePlugins = $input->hasParameterOption('--no-plugins');
@@ -321,7 +321,7 @@ abstract class BaseCommand extends Command
      *
      * @return list<array{name: string, version?: string}>
      */
-    protected function normalizeRequirements(array $requirements)
+    protected function normalizeRequirements(array $requirements): array
     {
         $parser = new VersionParser();
 
@@ -333,7 +333,7 @@ abstract class BaseCommand extends Command
      *
      * @return void
      */
-    protected function renderTable(array $table, OutputInterface $output)
+    protected function renderTable(array $table, OutputInterface $output): void
     {
         $renderer = new Table($output);
         $renderer->setStyle('compact');

--- a/src/Composer/Command/BaseDependencyCommand.php
+++ b/src/Composer/Command/BaseDependencyCommand.php
@@ -90,7 +90,7 @@ class BaseDependencyCommand extends BaseCommand
         $needles = array($needle);
         if ($inverted) {
             foreach ($packages as $package) {
-                $needles = array_merge($needles, array_map(function (Link $link) {
+                $needles = array_merge($needles, array_map(function (Link $link): string {
                     return $link->getTarget();
                 }, $package->getReplaces()));
             }

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -318,10 +318,10 @@ EOT
 
         $values = $input->getArgument('setting-value'); // what the user is trying to add/change
 
-        $booleanValidator = function ($val) {
+        $booleanValidator = function ($val): bool {
             return in_array($val, array('true', 'false', '1', '0'), true);
         };
-        $booleanNormalizer = function ($val) {
+        $booleanNormalizer = function ($val): bool {
             return $val !== 'false' && (bool) $val;
         };
 
@@ -331,7 +331,7 @@ EOT
             'use-include-path' => array($booleanValidator, $booleanNormalizer),
             'use-github-api' => array($booleanValidator, $booleanNormalizer),
             'preferred-install' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('auto', 'source', 'dist'), true);
                 },
                 function ($val) {
@@ -339,7 +339,7 @@ EOT
                 },
             ),
             'gitlab-protocol' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('git', 'http', 'https'), true);
                 },
                 function ($val) {
@@ -347,7 +347,7 @@ EOT
                 },
             ),
             'store-auths' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('true', 'false', 'prompt'), true);
                 },
                 function ($val) {
@@ -389,7 +389,7 @@ EOT
             'cache-ttl' => array('is_numeric', 'intval'),
             'cache-files-ttl' => array('is_numeric', 'intval'),
             'cache-files-maxsize' => array(
-                function ($val) {
+                function ($val): bool {
                     return Preg::isMatch('/^\s*([0-9.]+)\s*(?:([kmg])(?:i?b)?)?\s*$/i', $val);
                 },
                 function ($val) {
@@ -397,7 +397,7 @@ EOT
                 },
             ),
             'bin-compat' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('auto', 'full', 'symlink'));
                 },
                 function ($val) {
@@ -405,7 +405,7 @@ EOT
                 },
             ),
             'discard-changes' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('stash', 'true', 'false', '1', '0'), true);
                 },
                 function ($val) {
@@ -427,7 +427,7 @@ EOT
             'disable-tls' => array($booleanValidator, $booleanNormalizer),
             'secure-http' => array($booleanValidator, $booleanNormalizer),
             'cafile' => array(
-                function ($val) {
+                function ($val): bool {
                     return file_exists($val) && Filesystem::isReadable($val);
                 },
                 function ($val) {
@@ -435,7 +435,7 @@ EOT
                 },
             ),
             'capath' => array(
-                function ($val) {
+                function ($val): bool {
                     return is_dir($val) && Filesystem::isReadable($val);
                 },
                 function ($val) {
@@ -447,7 +447,7 @@ EOT
             'lock' => array($booleanValidator, $booleanNormalizer),
             'allow-plugins' => array($booleanValidator, $booleanNormalizer),
             'platform-check' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('php-only', 'true', 'false', '1', '0'), true);
                 },
                 function ($val) {
@@ -459,7 +459,7 @@ EOT
                 },
             ),
             'use-parent-dir' => array(
-                function ($val) {
+                function ($val): bool {
                     return in_array($val, array('true', 'false', 'prompt'), true);
                 },
                 function ($val) {
@@ -593,10 +593,10 @@ EOT
                 return $val;
             }),
             'minimum-stability' => array(
-                function ($val) {
+                function ($val): bool {
                     return isset(BasePackage::$stabilities[VersionParser::normalizeStability($val)]);
                 },
-                function ($val) {
+                function ($val): string {
                     return VersionParser::normalizeStability($val);
                 },
             ),

--- a/src/Composer/Command/DiagnoseCommand.php
+++ b/src/Composer/Command/DiagnoseCommand.php
@@ -52,7 +52,7 @@ class DiagnoseCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('diagnose')
@@ -511,7 +511,7 @@ EOT
     private function checkPlatform()
     {
         $output = '';
-        $out = function ($msg, $style) use (&$output) {
+        $out = function ($msg, $style) use (&$output): void {
             $output .= '<'.$style.'>'.$msg.'</'.$style.'>'.PHP_EOL;
         };
 

--- a/src/Composer/Command/DumpAutoloadCommand.php
+++ b/src/Composer/Command/DumpAutoloadCommand.php
@@ -26,7 +26,7 @@ class DumpAutoloadCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('dump-autoload')

--- a/src/Composer/Command/ExecCommand.php
+++ b/src/Composer/Command/ExecCommand.php
@@ -25,7 +25,7 @@ class ExecCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('exec')

--- a/src/Composer/Command/InitCommand.php
+++ b/src/Composer/Command/InitCommand.php
@@ -47,7 +47,7 @@ class InitCommand extends BaseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('init')
@@ -511,7 +511,7 @@ EOT
         }
 
         $namespace = array_map(
-            function ($part) {
+            function ($part): string {
                 $part = Preg::replace('/[^a-z0-9]/i', ' ', $part);
                 $part = ucwords($part);
 
@@ -591,7 +591,7 @@ EOT
      *
      * @return void
      */
-    protected function addVendorIgnore($ignoreFile, $vendor = '/vendor/')
+    protected function addVendorIgnore($ignoreFile, $vendor = '/vendor/'): void
     {
         $contents = "";
         if (file_exists($ignoreFile)) {

--- a/src/Composer/Command/InstallCommand.php
+++ b/src/Composer/Command/InstallCommand.php
@@ -32,7 +32,7 @@ class InstallCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('install')

--- a/src/Composer/Command/LicensesCommand.php
+++ b/src/Composer/Command/LicensesCommand.php
@@ -170,7 +170,7 @@ EOT
         $packageListNames = array_keys($bucket);
         $packages = array_filter(
             $repo->getPackages(),
-            function ($package) use ($requires, $packageListNames) {
+            function ($package) use ($requires, $packageListNames): bool {
                 return in_array($package->getName(), $requires) && !in_array($package->getName(), $packageListNames);
             }
         );

--- a/src/Composer/Command/ReinstallCommand.php
+++ b/src/Composer/Command/ReinstallCommand.php
@@ -123,7 +123,7 @@ EOT
                 $installOrder[$op->getPackage()->getName()] = $index;
             }
         }
-        usort($uninstallOperations, function ($a, $b) use ($installOrder) {
+        usort($uninstallOperations, function ($a, $b) use ($installOrder): int {
             return $installOrder[$b->getPackage()->getName()] - $installOrder[$a->getPackage()->getName()];
         });
 

--- a/src/Composer/Command/RemoveCommand.php
+++ b/src/Composer/Command/RemoveCommand.php
@@ -35,7 +35,7 @@ class RemoveCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('remove')
@@ -116,7 +116,7 @@ EOT
 
             if (count($input->getArgument('packages')) === 0) {
                 $this->getIO()->writeError('<info>No unused packages to remove</info>');
-                $this->setCode(function () {
+                $this->setCode(function (): int {
                     return 0;
                 });
             }

--- a/src/Composer/Command/RequireCommand.php
+++ b/src/Composer/Command/RequireCommand.php
@@ -61,7 +61,7 @@ class RequireCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('require')
@@ -339,7 +339,7 @@ EOT
      * @private
      * @return void
      */
-    public function markSolverComplete()
+    public function markSolverComplete(): void
     {
         $this->dependencyResolutionCompleted = true;
     }
@@ -480,7 +480,7 @@ EOT
      * @param bool $hardExit
      * @return void
      */
-    public function revertComposerFile($hardExit = true)
+    public function revertComposerFile($hardExit = true): void
     {
         $io = $this->getIO();
 

--- a/src/Composer/Command/SelfUpdateCommand.php
+++ b/src/Composer/Command/SelfUpdateCommand.php
@@ -354,7 +354,7 @@ TAGSPUBKEY
 
         $io->write('Open <info>https://composer.github.io/pubkeys.html</info> to find the latest keys');
 
-        $validator = function ($value) {
+        $validator = function ($value): string {
             if (!Preg::isMatch('{^-----BEGIN PUBLIC KEY-----$}', trim($value))) {
                 throw new \UnexpectedValueException('Invalid input');
             }

--- a/src/Composer/Command/ShowCommand.php
+++ b/src/Composer/Command/ShowCommand.php
@@ -67,7 +67,7 @@ class ShowCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('show')
@@ -223,7 +223,7 @@ EOT
 
             if ($input->getOption('no-dev')) {
                 $packages = $this->filterRequiredPackages($installedRepo, $rootPkg);
-                $repos = $installedRepo = new InstalledRepository(array(new InstalledArrayRepository(array_map(function ($pkg) {
+                $repos = $installedRepo = new InstalledRepository(array(new InstalledArrayRepository(array_map(function ($pkg): \Composer\Package\PackageInterface {
                     return clone $pkg;
                 }, $packages))));
             }
@@ -320,7 +320,7 @@ EOT
         if ($input->getOption('tree')) {
             $rootRequires = $this->getRootRequires();
             $packages = $installedRepo->getPackages();
-            usort($packages, function (BasePackage $a, BasePackage $b) {
+            usort($packages, function (BasePackage $a, BasePackage $b): int {
                 return strcmp((string) $a, (string) $b);
             });
             $arrayTree = array();
@@ -602,7 +602,7 @@ EOT
     /**
      * @return string[]
      */
-    protected function getRootRequires()
+    protected function getRootRequires(): array
     {
         $rootPackage = $this->requireComposer()->getPackage();
 
@@ -615,7 +615,7 @@ EOT
     /**
      * @return array|string|string[]
      */
-    protected function getVersionStyle(PackageInterface $latestPackage, PackageInterface $package)
+    protected function getVersionStyle(PackageInterface $latestPackage, PackageInterface $package): string
     {
         return $this->updateStatusToVersionStyle($this->getUpdateStatus($latestPackage, $package));
     }
@@ -677,7 +677,7 @@ EOT
      *
      * @return void
      */
-    protected function printPackageInfo(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null)
+    protected function printPackageInfo(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null): void
     {
         $io = $this->getIO();
 
@@ -705,7 +705,7 @@ EOT
      *
      * @return void
      */
-    protected function printMeta(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null)
+    protected function printMeta(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null): void
     {
         $io = $this->getIO();
         $io->write('<info>name</info>     : ' . $package->getPrettyName());
@@ -773,7 +773,7 @@ EOT
      *
      * @return void
      */
-    protected function printVersions(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo)
+    protected function printVersions(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo): void
     {
         $versions = array_keys($versions);
         $versions = Semver::rsort($versions);
@@ -802,7 +802,7 @@ EOT
      *
      * @return void
      */
-    protected function printLinks(CompletePackageInterface $package, $linkType, $title = null)
+    protected function printLinks(CompletePackageInterface $package, $linkType, $title = null): void
     {
         $title = $title ?: $linkType;
         $io = $this->getIO();
@@ -820,7 +820,7 @@ EOT
      *
      * @return void
      */
-    protected function printLicenses(CompletePackageInterface $package)
+    protected function printLicenses(CompletePackageInterface $package): void
     {
         $spdxLicenses = new SpdxLicenses();
 
@@ -852,7 +852,7 @@ EOT
      *
      * @return void
      */
-    protected function printPackageInfoAsJson(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null)
+    protected function printPackageInfoAsJson(CompletePackageInterface $package, array $versions, InstalledRepository $installedRepo, PackageInterface $latestPackage = null): void
     {
         $json = array(
             'name' => $package->getPrettyName(),
@@ -1030,7 +1030,7 @@ EOT
      *
      * @return void
      */
-    protected function initStyles(OutputInterface $output)
+    protected function initStyles(OutputInterface $output): void
     {
         $this->colors = array(
             'green',
@@ -1052,7 +1052,7 @@ EOT
      * @param array<int, array<string, string|mixed[]>> $arrayTree
      * @return void
      */
-    protected function displayPackageTree(array $arrayTree)
+    protected function displayPackageTree(array $arrayTree): void
     {
         $io = $this->getIO();
         foreach ($arrayTree as $package) {
@@ -1149,7 +1149,7 @@ EOT
         array $packagesInTree,
         $previousTreeBar = '├',
         $level = 1
-    ) {
+    ): void {
         $previousTreeBar = str_replace('├', '│', $previousTreeBar);
         if (is_array($package) && isset($package['requires'])) {
             $requires = $package['requires'];

--- a/src/Composer/Command/StatusCommand.php
+++ b/src/Composer/Command/StatusCommand.php
@@ -163,7 +163,7 @@ EOT
 
             foreach ($errors as $path => $changes) {
                 if ($input->getOption('verbose')) {
-                    $indentedChanges = implode("\n", array_map(function ($line) {
+                    $indentedChanges = implode("\n", array_map(function ($line): string {
                         return '    ' . ltrim($line);
                     }, explode("\n", $changes)));
                     $io->write('<info>'.$path.'</info>:');
@@ -179,7 +179,7 @@ EOT
 
             foreach ($unpushedChanges as $path => $changes) {
                 if ($input->getOption('verbose')) {
-                    $indentedChanges = implode("\n", array_map(function ($line) {
+                    $indentedChanges = implode("\n", array_map(function ($line): string {
                         return '    ' . ltrim($line);
                     }, explode("\n", $changes)));
                     $io->write('<info>'.$path.'</info>:');

--- a/src/Composer/Command/UpdateCommand.php
+++ b/src/Composer/Command/UpdateCommand.php
@@ -40,7 +40,7 @@ class UpdateCommand extends BaseCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('update')
@@ -129,7 +129,7 @@ EOT
 
         // extract --with shorthands from the allowlist
         if (count($packages) > 0) {
-            $allowlistPackagesWithRequirements = array_filter($packages, function ($pkg) {
+            $allowlistPackagesWithRequirements = array_filter($packages, function ($pkg): bool {
                 return Preg::isMatch('{\S+[ =:]\S+}', $pkg);
             });
             foreach ($this->formatRequirements($allowlistPackagesWithRequirements) as $package => $constraint) {
@@ -180,7 +180,7 @@ EOT
 
         // the arguments lock/nothing/mirrors are not package names but trigger a mirror update instead
         // they are further mutually exclusive with listing actual package names
-        $filteredPackages = array_filter($packages, function ($package) {
+        $filteredPackages = array_filter($packages, function ($package): bool {
             return !in_array($package, array('lock', 'nothing', 'mirrors'), true);
         });
         $updateMirrors = $input->getOption('lock') || count($filteredPackages) != count($packages);

--- a/src/Composer/Command/ValidateCommand.php
+++ b/src/Composer/Command/ValidateCommand.php
@@ -193,13 +193,13 @@ EOT
         }
 
         if ($errors) {
-            $errors = array_map(function ($err) {
+            $errors = array_map(function ($err): string {
                 return '- ' . $err;
             }, $errors);
             array_unshift($errors, '# General errors');
         }
         if ($warnings) {
-            $warnings = array_map(function ($err) {
+            $warnings = array_map(function ($err): string {
                 return '- ' . $err;
             }, $warnings);
             array_unshift($warnings, '# General warnings');
@@ -210,7 +210,7 @@ EOT
 
         // If checking publish errors, display them as errors, otherwise just show them as warnings
         if ($publishErrors) {
-            $publishErrors = array_map(function ($err) {
+            $publishErrors = array_map(function ($err): string {
                 return '- ' . $err;
             }, $publishErrors);
 

--- a/src/Composer/Compiler.php
+++ b/src/Composer/Compiler.php
@@ -82,7 +82,7 @@ class Compiler
 
         $phar->startBuffering();
 
-        $finderSort = function ($a, $b) {
+        $finderSort = function ($a, $b): int {
             return strcmp(strtr($a->getRealPath(), '\\', '/'), strtr($b->getRealPath(), '\\', '/'));
         };
 

--- a/src/Composer/Config/JsonConfigSource.php
+++ b/src/Composer/Config/JsonConfigSource.php
@@ -52,7 +52,7 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->file->getPath();
     }
@@ -60,9 +60,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function addRepository($name, $config, $append = true)
+    public function addRepository($name, $config, $append = true): void
     {
-        $this->manipulateJson('addRepository', function (&$config, $repo, $repoConfig) use ($append) {
+        $this->manipulateJson('addRepository', function (&$config, $repo, $repoConfig) use ($append): void {
             // if converting from an array format to hashmap format, and there is a {"packagist.org":false} repo, we have
             // to convert it to "packagist.org": false key on the hashmap otherwise it fails schema validation
             if (isset($config['repositories'])) {
@@ -89,9 +89,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function removeRepository($name)
+    public function removeRepository($name): void
     {
-        $this->manipulateJson('removeRepository', function (&$config, $repo) {
+        $this->manipulateJson('removeRepository', function (&$config, $repo): void {
             unset($config['repositories'][$repo]);
         }, $name);
     }
@@ -99,10 +99,10 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function addConfigSetting($name, $value)
+    public function addConfigSetting($name, $value): void
     {
         $authConfig = $this->authConfig;
-        $this->manipulateJson('addConfigSetting', function (&$config, $key, $val) use ($authConfig) {
+        $this->manipulateJson('addConfigSetting', function (&$config, $key, $val) use ($authConfig): void {
             if (Preg::isMatch('{^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|bearer|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
@@ -119,10 +119,10 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function removeConfigSetting($name)
+    public function removeConfigSetting($name): void
     {
         $authConfig = $this->authConfig;
-        $this->manipulateJson('removeConfigSetting', function (&$config, $key) use ($authConfig) {
+        $this->manipulateJson('removeConfigSetting', function (&$config, $key) use ($authConfig): void {
             if (Preg::isMatch('{^(bitbucket-oauth|github-oauth|gitlab-oauth|gitlab-token|bearer|http-basic|platform)\.}', $key)) {
                 list($key, $host) = explode('.', $key, 2);
                 if ($authConfig) {
@@ -139,9 +139,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function addProperty($name, $value)
+    public function addProperty($name, $value): void
     {
-        $this->manipulateJson('addProperty', function (&$config, $key, $val) {
+        $this->manipulateJson('addProperty', function (&$config, $key, $val): void {
             if (strpos($key, 'extra.') === 0 || strpos($key, 'scripts.') === 0) {
                 $bits = explode('.', $key);
                 $last = array_pop($bits);
@@ -162,9 +162,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function removeProperty($name)
+    public function removeProperty($name): void
     {
-        $this->manipulateJson('removeProperty', function (&$config, $key) {
+        $this->manipulateJson('removeProperty', function (&$config, $key): void {
             if (strpos($key, 'extra.') === 0 || strpos($key, 'scripts.') === 0) {
                 $bits = explode('.', $key);
                 $last = array_pop($bits);
@@ -185,9 +185,9 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function addLink($type, $name, $value)
+    public function addLink($type, $name, $value): void
     {
-        $this->manipulateJson('addLink', function (&$config, $type, $name, $value) {
+        $this->manipulateJson('addLink', function (&$config, $type, $name, $value): void {
             $config[$type][$name] = $value;
         }, $type, $name, $value);
     }
@@ -195,12 +195,12 @@ class JsonConfigSource implements ConfigSourceInterface
     /**
      * @inheritDoc
      */
-    public function removeLink($type, $name)
+    public function removeLink($type, $name): void
     {
-        $this->manipulateJson('removeSubNode', function (&$config, $type, $name) {
+        $this->manipulateJson('removeSubNode', function (&$config, $type, $name): void {
             unset($config[$type][$name]);
         }, $type, $name);
-        $this->manipulateJson('removeMainKeyIfEmpty', function (&$config, $type) {
+        $this->manipulateJson('removeMainKeyIfEmpty', function (&$config, $type): void {
             if (0 === count($config[$type])) {
                 unset($config[$type]);
             }

--- a/src/Composer/Console/Application.php
+++ b/src/Composer/Console/Application.php
@@ -94,14 +94,14 @@ class Application extends BaseApplication
         if (!$shutdownRegistered) {
             if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
                 pcntl_async_signals(true);
-                pcntl_signal(SIGINT, function ($sig) {
+                pcntl_signal(SIGINT, function ($sig): void {
                     exit(130);
                 });
             }
 
             $shutdownRegistered = true;
 
-            register_shutdown_function(function () {
+            register_shutdown_function(function (): void {
                 $lastError = error_get_last();
 
                 if ($lastError && $lastError['message'] &&
@@ -291,7 +291,7 @@ class Application extends BaseApplication
             }
 
             // Check system temp folder for usability as it can cause weird runtime issues otherwise
-            Silencer::call(function () use ($io) {
+            Silencer::call(function () use ($io): void {
                 $tempfile = sys_get_temp_dir() . '/temp-' . md5(microtime());
                 if (!(file_put_contents($tempfile, __FILE__) && (file_get_contents($tempfile) == __FILE__) && unlink($tempfile) && !file_exists($tempfile))) {
                     $io->writeError(sprintf('<error>PHP temp directory (%s) does not exist or is not writable to Composer. Set sys_temp_dir in your php.ini</error>', sys_get_temp_dir()));
@@ -459,7 +459,7 @@ class Application extends BaseApplication
      *
      * @return void
      */
-    public function resetComposer()
+    public function resetComposer(): void
     {
         $this->composer = null;
         if (method_exists($this->getIO(), 'resetAuthentications')) {

--- a/src/Composer/DependencyResolver/DefaultPolicy.php
+++ b/src/Composer/DependencyResolver/DefaultPolicy.php
@@ -66,7 +66,7 @@ class DefaultPolicy implements PolicyInterface
         $packages = $this->groupLiteralsByName($pool, $literals);
 
         foreach ($packages as &$nameLiterals) {
-            usort($nameLiterals, function ($a, $b) use ($pool, $requiredPackage) {
+            usort($nameLiterals, function ($a, $b) use ($pool, $requiredPackage): int {
                 return $this->compareByPriority($pool, $pool->literalToPackage($a), $pool->literalToPackage($b), $requiredPackage, true);
             });
         }
@@ -79,7 +79,7 @@ class DefaultPolicy implements PolicyInterface
         $selected = \call_user_func_array('array_merge', array_values($packages));
 
         // now sort the result across all packages to respect replaces across packages
-        usort($selected, function ($a, $b) use ($pool, $requiredPackage) {
+        usort($selected, function ($a, $b) use ($pool, $requiredPackage): int {
             return $this->compareByPriority($pool, $pool->literalToPackage($a), $pool->literalToPackage($b), $requiredPackage);
         });
 

--- a/src/Composer/DependencyResolver/LockTransaction.php
+++ b/src/Composer/DependencyResolver/LockTransaction.php
@@ -152,7 +152,7 @@ class LockTransaction extends Transaction
             }
         }
 
-        usort($usedAliases, function ($a, $b) {
+        usort($usedAliases, function ($a, $b): int {
             return strcmp($a['package'], $b['package']);
         });
 

--- a/src/Composer/DependencyResolver/Operation/InstallOperation.php
+++ b/src/Composer/DependencyResolver/Operation/InstallOperation.php
@@ -46,7 +46,7 @@ class InstallOperation extends SolverOperation implements OperationInterface
     /**
      * @inheritDoc
      */
-    public function show($lock)
+    public function show($lock): string
     {
         return self::format($this->package, $lock);
     }

--- a/src/Composer/DependencyResolver/PoolBuilder.php
+++ b/src/Composer/DependencyResolver/PoolBuilder.php
@@ -520,7 +520,7 @@ class PoolBuilder
         $matches = array();
 
         if (isset($rootRequires[$name])) {
-            return array_map(function (PackageInterface $package) use ($name) {
+            return array_map(function (PackageInterface $package) use ($name): string {
                 if ($name !== $package->getName()) {
                     return $package->getName() .' (via replace of '.$name.')';
                 }

--- a/src/Composer/DependencyResolver/Problem.php
+++ b/src/Composer/DependencyResolver/Problem.php
@@ -286,7 +286,7 @@ class Problem
         if ($packages = $repositorySet->findPackages($packageName, $constraint)) {
             $rootReqs = $repositorySet->getRootRequires();
             if (isset($rootReqs[$packageName])) {
-                $filtered = array_filter($packages, function ($p) use ($rootReqs, $packageName) {
+                $filtered = array_filter($packages, function ($p) use ($rootReqs, $packageName): bool {
                     return $rootReqs[$packageName]->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
@@ -296,7 +296,7 @@ class Problem
 
             if ($lockedPackage) {
                 $fixedConstraint = new Constraint('==', $lockedPackage->getVersion());
-                $filtered = array_filter($packages, function ($p) use ($fixedConstraint) {
+                $filtered = array_filter($packages, function ($p) use ($fixedConstraint): bool {
                     return $fixedConstraint->matches(new Constraint('==', $p->getVersion()));
                 });
                 if (0 === count($filtered)) {
@@ -304,7 +304,7 @@ class Problem
                 }
             }
 
-            $nonLockedPackages = array_filter($packages, function ($p) {
+            $nonLockedPackages = array_filter($packages, function ($p): bool {
                 return !$p->getRepository() instanceof LockArrayRepository;
             });
 
@@ -360,7 +360,7 @@ class Problem
 
         if ($providers = $repositorySet->getProviders($packageName)) {
             $maxProviders = 20;
-            $providersStr = implode(array_map(function ($p) {
+            $providersStr = implode(array_map(function ($p): string {
                 $description = $p['description'] ? ' '.substr($p['description'], 0, 100) : '';
 
                 return "      - ${p['name']}".$description."\n";

--- a/src/Composer/DependencyResolver/Rule.php
+++ b/src/Composer/DependencyResolver/Rule.php
@@ -281,7 +281,7 @@ abstract class Rule
                     return 'No package found to satisfy root composer.json require '.$packageName.($constraint ? ' '.$constraint->getPrettyString() : '');
                 }
 
-                $packagesNonAlias = array_values(array_filter($packages, function ($p) {
+                $packagesNonAlias = array_values(array_filter($packages, function ($p): bool {
                     return !($p instanceof AliasPackage);
                 }));
                 if (count($packagesNonAlias) === 1) {

--- a/src/Composer/DependencyResolver/RuleWatchGraph.php
+++ b/src/Composer/DependencyResolver/RuleWatchGraph.php
@@ -110,7 +110,7 @@ class RuleWatchGraph
                 if (!$node->getRule()->isDisabled() && !$decisions->satisfy($otherWatch)) {
                     $ruleLiterals = $node->getRule()->getLiterals();
 
-                    $alternativeLiterals = array_filter($ruleLiterals, function ($ruleLiteral) use ($literal, $otherWatch, $decisions) {
+                    $alternativeLiterals = array_filter($ruleLiterals, function ($ruleLiteral) use ($literal, $otherWatch, $decisions): bool {
                         return $literal !== $ruleLiteral &&
                             $otherWatch !== $ruleLiteral &&
                             !$decisions->conflict($ruleLiteral);

--- a/src/Composer/DependencyResolver/Transaction.php
+++ b/src/Composer/DependencyResolver/Transaction.php
@@ -71,7 +71,7 @@ class Transaction
      */
     private function setResultPackageMaps($resultPackages): void
     {
-        $packageSort = function (PackageInterface $a, PackageInterface $b) {
+        $packageSort = function (PackageInterface $a, PackageInterface $b): int {
             // sort alias packages by the same name behind their non alias version
             if ($a->getName() == $b->getName()) {
                 if ($a instanceof AliasPackage != $b instanceof AliasPackage) {
@@ -289,7 +289,7 @@ class Transaction
             // is this a downloads modifying plugin or a dependency of one?
             if ($isDownloadsModifyingPlugin || count(array_intersect($package->getNames(), $dlModifyingPluginRequires))) {
                 // get the package's requires, but filter out any platform requirements
-                $requires = array_filter(array_keys($package->getRequires()), function ($req) {
+                $requires = array_filter(array_keys($package->getRequires()), function ($req): bool {
                     return !PlatformRepository::isPlatformPackage($req);
                 });
 
@@ -314,7 +314,7 @@ class Transaction
             // is this a plugin or a dependency of a plugin?
             if ($isPlugin || count(array_intersect($package->getNames(), $pluginRequires))) {
                 // get the package's requires, but filter out any platform requirements
-                $requires = array_filter(array_keys($package->getRequires()), function ($req) {
+                $requires = array_filter(array_keys($package->getRequires()), function ($req): bool {
                     return !PlatformRepository::isPlatformPackage($req);
                 });
 

--- a/src/Composer/Downloader/ArchiveDownloader.php
+++ b/src/Composer/Downloader/ArchiveDownloader.php
@@ -34,7 +34,7 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * @return PromiseInterface|null
      */
-    public function prepare($type, PackageInterface $package, $path, PackageInterface $prevPackage = null)
+    public function prepare($type, PackageInterface $package, $path, PackageInterface $prevPackage = null): ?\React\Promise\PromiseInterface
     {
         unset($this->cleanupExecuted[$package->getName()]);
 
@@ -44,7 +44,7 @@ abstract class ArchiveDownloader extends FileDownloader
     /**
      * @return PromiseInterface|null
      */
-    public function cleanup($type, PackageInterface $package, $path, PackageInterface $prevPackage = null)
+    public function cleanup($type, PackageInterface $package, $path, PackageInterface $prevPackage = null): ?\React\Promise\PromiseInterface
     {
         $this->cleanupExecuted[$package->getName()] = true;
 
@@ -92,7 +92,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
         $filesystem = $this->filesystem;
 
-        $cleanup = function () use ($path, $filesystem, $temporaryDir, $package) {
+        $cleanup = function () use ($path, $filesystem, $temporaryDir, $package): void {
             // remove cache if the file was corrupted
             $this->clearLastCacheWrite($package);
 
@@ -116,7 +116,7 @@ abstract class ArchiveDownloader extends FileDownloader
             $promise = \React\Promise\resolve();
         }
 
-        return $promise->then(function () use ($package, $filesystem, $fileName, $temporaryDir, $path) {
+        return $promise->then(function () use ($package, $filesystem, $fileName, $temporaryDir, $path): \React\Promise\PromiseInterface {
             $filesystem->unlink($fileName);
 
             /**
@@ -125,7 +125,7 @@ abstract class ArchiveDownloader extends FileDownloader
              * @param  string         $dir Directory
              * @return \SplFileInfo[]
              */
-            $getFolderContent = function ($dir) {
+            $getFolderContent = function ($dir): array {
                 $finder = Finder::create()
                     ->ignoreVCS(false)
                     ->ignoreDotFiles(false)
@@ -200,7 +200,7 @@ abstract class ArchiveDownloader extends FileDownloader
 
             $promise = $filesystem->removeDirectoryAsync($temporaryDir);
 
-            return $promise->then(function () use ($package, $path, $temporaryDir) {
+            return $promise->then(function () use ($package, $path, $temporaryDir): void {
                 $this->removeCleanupPath($package, $temporaryDir);
                 $this->removeCleanupPath($package, $path);
             });

--- a/src/Composer/Downloader/DownloadManager.php
+++ b/src/Composer/Downloader/DownloadManager.php
@@ -331,7 +331,7 @@ class DownloadManager
         // we wipe the dir and do a new install instead of updating it
         $promise = $initialDownloader->remove($initial, $targetDir);
         if ($promise) {
-            return $promise->then(function ($res) use ($target, $targetDir) {
+            return $promise->then(function ($res) use ($target, $targetDir): ?\React\Promise\PromiseInterface {
                 return $this->install($target, $targetDir);
             });
         }
@@ -432,7 +432,7 @@ class DownloadManager
             && !(!$prevPackage->isDev() && $prevPackage->getInstallationSource() === 'dist' && $package->isDev())
         ) {
             $prevSource = $prevPackage->getInstallationSource();
-            usort($sources, function ($a, $b) use ($prevSource) {
+            usort($sources, function ($a, $b) use ($prevSource): int {
                 return $a === $prevSource ? -1 : 1;
             });
 

--- a/src/Composer/Downloader/FileDownloader.php
+++ b/src/Composer/Downloader/FileDownloader.php
@@ -118,7 +118,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             throw new \InvalidArgumentException('The given package is missing url information');
         }
 
-        $cacheKeyGenerator = function (PackageInterface $package, $key) {
+        $cacheKeyGenerator = function (PackageInterface $package, $key): string {
             $cacheKey = sha1($key);
 
             return $package->getName().'/'.$cacheKey.'.'.$package->getDistType();
@@ -195,7 +195,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
                     ->then($accept, $reject);
             }
 
-            return $result->then(function ($result) use ($fileName, $checksum, $url, $package, $eventDispatcher) {
+            return $result->then(function ($result) use ($fileName, $checksum, $url, $package, $eventDispatcher): string {
                 // in case of retry, the first call's Promise chain finally calls this twice at the end,
                 // once with $result being the returned $fileName from $accept, and then once for every
                 // failed request with a null result, which can be skipped.
@@ -221,7 +221,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             });
         };
 
-        $accept = function ($response) use ($cache, $package, $fileName, &$urls) {
+        $accept = function ($response) use ($cache, $package, $fileName, &$urls): string {
             $url = reset($urls);
             $cacheKey = $url['cacheKey'];
             FileDownloader::$downloadMetadata[$package->getName()] = @filesize($fileName) ?: $response->getHeader('Content-Length') ?: '?';
@@ -362,7 +362,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
     /**
      * @return void
      */
-    protected function clearLastCacheWrite(PackageInterface $package)
+    protected function clearLastCacheWrite(PackageInterface $package): void
     {
         if ($this->cache && isset($this->lastCacheWrites[$package->getName()])) {
             $this->cache->remove($this->lastCacheWrites[$package->getName()]);
@@ -375,7 +375,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      *
      * @return void
      */
-    protected function addCleanupPath(PackageInterface $package, $path)
+    protected function addCleanupPath(PackageInterface $package, $path): void
     {
         $this->additionalCleanupPaths[$package->getName()][] = $path;
     }
@@ -385,7 +385,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      *
      * @return void
      */
-    protected function removeCleanupPath(PackageInterface $package, $path)
+    protected function removeCleanupPath(PackageInterface $package, $path): void
     {
         if (isset($this->additionalCleanupPaths[$package->getName()])) {
             $idx = array_search($path, $this->additionalCleanupPaths[$package->getName()]);
@@ -407,7 +407,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
             $promise = \React\Promise\resolve();
         }
 
-        return $promise->then(function () use ($target, $path) {
+        return $promise->then(function () use ($target, $path): ?\React\Promise\PromiseInterface {
             $promise = $this->install($target, $path, false);
 
             return $promise;
@@ -419,14 +419,14 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      *
      * @param bool $output
      */
-    public function remove(PackageInterface $package, $path, $output = true)
+    public function remove(PackageInterface $package, $path, $output = true): \React\Promise\PromiseInterface
     {
         if ($output) {
             $this->io->writeError("  - " . UninstallOperation::format($package));
         }
         $promise = $this->filesystem->removeDirectoryAsync($path);
 
-        return $promise->then(function ($result) use ($path) {
+        return $promise->then(function ($result) use ($path): void {
             if (!$result) {
                 throw new \RuntimeException('Could not completely delete '.$path.', aborting.');
             }
@@ -440,7 +440,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      * @param  string           $path    download path
      * @return string           file name
      */
-    protected function getFileName(PackageInterface $package, $path)
+    protected function getFileName(PackageInterface $package, $path): string
     {
         return rtrim($this->config->get('vendor-dir').'/composer/tmp-'.md5($package.spl_object_hash($package)).'.'.pathinfo(parse_url($package->getDistUrl(), PHP_URL_PATH), PATHINFO_EXTENSION), '.');
     }
@@ -482,7 +482,7 @@ class FileDownloader implements DownloaderInterface, ChangeReportInterface
      * @inheritDoc
      * @throws \RuntimeException
      */
-    public function getLocalChanges(PackageInterface $package, $targetDir)
+    public function getLocalChanges(PackageInterface $package, $targetDir): string
     {
         $prevIO = $this->io;
 

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -114,7 +114,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         $this->io->writeError($msg);
 
-        $commandCallable = function ($url) use ($path, $command, $cachePath) {
+        $commandCallable = function ($url) use ($path, $command, $cachePath): string {
             return str_replace(
                 array('%url%', '%path%', '%cachePath%', '%sanitizedUrl%'),
                 array(
@@ -172,7 +172,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
 
         $this->io->writeError($msg);
 
-        $commandCallable = function ($url) use ($ref, $command, $cachePath) {
+        $commandCallable = function ($url) use ($ref, $command, $cachePath): string {
             return str_replace(
                 array('%url%', '%ref%', '%cachePath%', '%sanitizedUrl%'),
                 array(
@@ -358,7 +358,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
             return parent::cleanChanges($package, $path, $update);
         }
 
-        $changes = array_map(function ($elem) {
+        $changes = array_map(function ($elem): string {
             return '    '.$elem;
         }, Preg::split('{\s*\r?\n\s*}', $changes));
         $this->io->writeError('    <error>'.$package->getPrettyName().' has modified files:</error>');
@@ -505,7 +505,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
      *
      * @return void
      */
-    protected function updateOriginUrl($path, $url)
+    protected function updateOriginUrl($path, $url): void
     {
         $this->process->execute(sprintf('git remote set-url origin -- %s', ProcessExecutor::escape($url)), $output, $path);
         $this->setPushUrl($path, $url);
@@ -517,7 +517,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
      *
      * @return void
      */
-    protected function setPushUrl($path, $url)
+    protected function setPushUrl($path, $url): void
     {
         // set push url for github projects
         if (Preg::isMatch('{^(?:https?|git)://'.GitUtil::getGitHubDomainsRegex($this->config).'/([^/]+)/([^/]+?)(?:\.git)?$}', $url, $match)) {
@@ -630,7 +630,7 @@ class GitDownloader extends VcsDownloader implements DvcsDownloaderInterface
     /**
      * @inheritDoc
      */
-    protected function hasMetadataRepository($path)
+    protected function hasMetadataRepository($path): bool
     {
         $path = $this->normalizePath($path);
 

--- a/src/Composer/Downloader/HgDownloader.php
+++ b/src/Composer/Downloader/HgDownloader.php
@@ -41,7 +41,7 @@ class HgDownloader extends VcsDownloader
     {
         $hgUtils = new HgUtils($this->io, $this->config, $this->process);
 
-        $cloneCommand = function ($url) use ($path) {
+        $cloneCommand = function ($url) use ($path): string {
             return sprintf('hg clone -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($path));
         };
 
@@ -70,7 +70,7 @@ class HgDownloader extends VcsDownloader
             throw new \RuntimeException('The .hg directory is missing from '.$path.', see https://getcomposer.org/commit-deps for more information');
         }
 
-        $command = function ($url) use ($ref) {
+        $command = function ($url) use ($ref): string {
             return sprintf('hg pull -- %s && hg up -- %s', ProcessExecutor::escape($url), ProcessExecutor::escape($ref));
         };
 

--- a/src/Composer/Downloader/SvnDownloader.php
+++ b/src/Composer/Downloader/SvnDownloader.php
@@ -144,7 +144,7 @@ class SvnDownloader extends VcsDownloader
             return parent::cleanChanges($package, $path, $update);
         }
 
-        $changes = array_map(function ($elem) {
+        $changes = array_map(function ($elem): string {
             return '    '.$elem;
         }, Preg::split('{\s*\r?\n\s*}', $changes));
         $countChanges = count($changes);
@@ -248,7 +248,7 @@ class SvnDownloader extends VcsDownloader
     /**
      * @inheritDoc
      */
-    protected function hasMetadataRepository($path)
+    protected function hasMetadataRepository($path): bool
     {
         return is_dir($path.'/.svn');
     }

--- a/src/Composer/Downloader/VcsDownloader.php
+++ b/src/Composer/Downloader/VcsDownloader.php
@@ -200,7 +200,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
             }
 
             if (trim($logs)) {
-                $logs = implode("\n", array_map(function ($line) {
+                $logs = implode("\n", array_map(function ($line): string {
                     return '      ' . $line;
                 }, explode("\n", $logs)));
 
@@ -222,7 +222,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
     /**
      * @inheritDoc
      */
-    public function remove(PackageInterface $package, $path)
+    public function remove(PackageInterface $package, $path): \React\Promise\PromiseInterface
     {
         $this->io->writeError("  - " . UninstallOperation::format($package));
 
@@ -283,7 +283,7 @@ abstract class VcsDownloader implements DownloaderInterface, ChangeReportInterfa
      *
      * @throws \RuntimeException in case the operation must be aborted or the patch does not apply cleanly
      */
-    protected function reapplyChanges($path)
+    protected function reapplyChanges($path): void
     {
     }
 

--- a/src/Composer/Downloader/ZipDownloader.php
+++ b/src/Composer/Downloader/ZipDownloader.php
@@ -38,7 +38,7 @@ class ZipDownloader extends ArchiveDownloader
     /**
      * @inheritDoc
      */
-    public function download(PackageInterface $package, $path, PackageInterface $prevPackage = null, $output = true)
+    public function download(PackageInterface $package, $path, PackageInterface $prevPackage = null, $output = true): ?\React\Promise\PromiseInterface
     {
         if (null === self::$unzipCommands) {
             self::$unzipCommands = array();
@@ -127,7 +127,7 @@ class ZipDownloader extends ArchiveDownloader
         $executable = $commandSpec[0];
 
         $io = $this->io;
-        $tryFallback = function ($processError) use ($isLastChance, $io, $file, $path, $package, $executable) {
+        $tryFallback = function ($processError) use ($isLastChance, $io, $file, $path, $package, $executable): \React\Promise\PromiseInterface {
             if ($isLastChance) {
                 throw $processError;
             }
@@ -207,7 +207,7 @@ class ZipDownloader extends ArchiveDownloader
      * @param  string                $path Path where to extract file
      * @return PromiseInterface|null
      */
-    protected function extract(PackageInterface $package, $file, $path)
+    protected function extract(PackageInterface $package, $file, $path): \React\Promise\PromiseInterface
     {
         return $this->extractWithSystemUnzip($package, $file, $path);
     }
@@ -219,7 +219,7 @@ class ZipDownloader extends ArchiveDownloader
      * @param  string $file
      * @return string
      */
-    protected function getErrorMessage($retval, $file)
+    protected function getErrorMessage($retval, $file): string
     {
         switch ($retval) {
             case ZipArchive::ER_EXISTS:

--- a/src/Composer/EventDispatcher/Event.php
+++ b/src/Composer/EventDispatcher/Event.php
@@ -98,7 +98,7 @@ class Event
      *
      * @return void
      */
-    public function stopPropagation()
+    public function stopPropagation(): void
     {
         $this->propagationStopped = true;
     }

--- a/src/Composer/EventDispatcher/EventDispatcher.php
+++ b/src/Composer/EventDispatcher/EventDispatcher.php
@@ -97,7 +97,7 @@ class EventDispatcher
      * @return int    return code of the executed script if any, for php scripts a false return
      *                          value is changed to 1, anything else to 0
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, Event $event = null): int
     {
         if (null === $event) {
             $event = new Event($eventName);
@@ -116,7 +116,7 @@ class EventDispatcher
      * @return int                                  return code of the executed script if any, for php scripts a false return
      *                                              value is changed to 1, anything else to 0
      */
-    public function dispatchScript($eventName, $devMode = false, $additionalArgs = array(), $flags = array())
+    public function dispatchScript($eventName, $devMode = false, $additionalArgs = array(), $flags = array()): int
     {
         assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));
 
@@ -135,7 +135,7 @@ class EventDispatcher
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchPackageEvent($eventName, $devMode, RepositoryInterface $localRepo, array $operations, OperationInterface $operation)
+    public function dispatchPackageEvent($eventName, $devMode, RepositoryInterface $localRepo, array $operations, OperationInterface $operation): int
     {
         assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));
 
@@ -153,7 +153,7 @@ class EventDispatcher
      * @return int return code of the executed script if any, for php scripts a false return
      *             value is changed to 1, anything else to 0
      */
-    public function dispatchInstallerEvent($eventName, $devMode, $executeOperations, Transaction $transaction)
+    public function dispatchInstallerEvent($eventName, $devMode, $executeOperations, Transaction $transaction): int
     {
         assert($this->composer instanceof Composer, new \LogicException('This should only be reached with a fully loaded Composer'));
 
@@ -343,7 +343,7 @@ class EventDispatcher
      *
      * @return int
      */
-    protected function executeTty($exec)
+    protected function executeTty($exec): int
     {
         if ($this->io->isInteractive()) {
             return $this->process->executeTty($exec);
@@ -398,7 +398,7 @@ class EventDispatcher
      *
      * @return void
      */
-    public function addListener($eventName, $listener, $priority = 0)
+    public function addListener($eventName, $listener, $priority = 0): void
     {
         $this->listeners[$eventName][$priority][] = $listener;
     }
@@ -408,7 +408,7 @@ class EventDispatcher
      *
      * @return void
      */
-    public function removeListener($listener)
+    public function removeListener($listener): void
     {
         foreach ($this->listeners as $eventName => $priorities) {
             foreach ($priorities as $priority => $listeners) {
@@ -430,7 +430,7 @@ class EventDispatcher
      *
      * @return void
      */
-    public function addSubscriber(EventSubscriberInterface $subscriber)
+    public function addSubscriber(EventSubscriberInterface $subscriber): void
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (is_string($params)) {
@@ -543,7 +543,7 @@ class EventDispatcher
      * @throws \RuntimeException
      * @return int
      */
-    protected function pushEvent(Event $event)
+    protected function pushEvent(Event $event): int
     {
         $eventName = $event->getName();
         if (in_array($eventName, $this->eventStack)) {

--- a/src/Composer/IO/BaseIO.php
+++ b/src/Composer/IO/BaseIO.php
@@ -33,7 +33,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @return void
      */
-    public function resetAuthentications()
+    public function resetAuthentications(): void
     {
         $this->authentications = array();
     }
@@ -61,7 +61,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function setAuthentication($repositoryName, $username, $password = null)
+    public function setAuthentication($repositoryName, $username, $password = null): void
     {
         $this->authentications[$repositoryName] = array('username' => $username, 'password' => $password);
     }
@@ -69,7 +69,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeRaw($messages, $newline = true, $verbosity = self::NORMAL)
+    public function writeRaw($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->write($messages, $newline, $verbosity);
     }
@@ -77,7 +77,7 @@ abstract class BaseIO implements IOInterface
     /**
      * @inheritDoc
      */
-    public function writeErrorRaw($messages, $newline = true, $verbosity = self::NORMAL)
+    public function writeErrorRaw($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->writeError($messages, $newline, $verbosity);
     }
@@ -91,7 +91,7 @@ abstract class BaseIO implements IOInterface
      *
      * @return void
      */
-    protected function checkAndSetAuthentication($repositoryName, $username, $password = null)
+    protected function checkAndSetAuthentication($repositoryName, $username, $password = null): void
     {
         if ($this->hasAuthentication($repositoryName)) {
             $auth = $this->getAuthentication($repositoryName);

--- a/src/Composer/IO/BufferIO.php
+++ b/src/Composer/IO/BufferIO.php
@@ -56,7 +56,7 @@ class BufferIO extends ConsoleIO
 
         $output = stream_get_contents($this->output->getStream());
 
-        $output = Preg::replaceCallback("{(?<=^|\n|\x08)(.+?)(\x08+)}", function ($matches) {
+        $output = Preg::replaceCallback("{(?<=^|\n|\x08)(.+?)(\x08+)}", function ($matches): string {
             $pre = strip_tags($matches[1]);
 
             if (strlen($pre) === strlen($matches[2])) {

--- a/src/Composer/IO/ConsoleIO.php
+++ b/src/Composer/IO/ConsoleIO.php
@@ -71,7 +71,7 @@ class ConsoleIO extends BaseIO
      *
      * @return void
      */
-    public function enableDebugging($startTime)
+    public function enableDebugging($startTime): void
     {
         $this->startTime = $startTime;
     }
@@ -79,7 +79,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function isInteractive()
+    public function isInteractive(): bool
     {
         return $this->input->isInteractive();
     }
@@ -87,7 +87,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function isDecorated()
+    public function isDecorated(): bool
     {
         return $this->output->isDecorated();
     }
@@ -95,7 +95,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function isVerbose()
+    public function isVerbose(): bool
     {
         return $this->output->isVerbose();
     }
@@ -103,7 +103,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function isVeryVerbose()
+    public function isVeryVerbose(): bool
     {
         return $this->output->isVeryVerbose();
     }
@@ -111,7 +111,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function isDebug()
+    public function isDebug(): bool
     {
         return $this->output->isDebug();
     }
@@ -119,7 +119,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function write($messages, $newline = true, $verbosity = self::NORMAL)
+    public function write($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, false, $verbosity);
     }
@@ -127,7 +127,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeError($messages, $newline = true, $verbosity = self::NORMAL)
+    public function writeError($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, true, $verbosity);
     }
@@ -135,7 +135,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeRaw($messages, $newline = true, $verbosity = self::NORMAL)
+    public function writeRaw($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, false, $verbosity, true);
     }
@@ -143,7 +143,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function writeErrorRaw($messages, $newline = true, $verbosity = self::NORMAL)
+    public function writeErrorRaw($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         $this->doWrite($messages, $newline, true, $verbosity, true);
     }
@@ -175,7 +175,7 @@ class ConsoleIO extends BaseIO
         if (null !== $this->startTime) {
             $memoryUsage = memory_get_usage() / 1024 / 1024;
             $timeSpent = microtime(true) - $this->startTime;
-            $messages = array_map(function ($message) use ($memoryUsage, $timeSpent) {
+            $messages = array_map(function ($message) use ($memoryUsage, $timeSpent): string {
                 return sprintf('[%.1fMiB/%.2fs] %s', $memoryUsage, $timeSpent, $message);
             }, (array) $messages);
         }
@@ -194,7 +194,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function overwrite($messages, $newline = true, $size = null, $verbosity = self::NORMAL)
+    public function overwrite($messages, $newline = true, $size = null, $verbosity = self::NORMAL): void
     {
         $this->doOverwrite($messages, $newline, $size, false, $verbosity);
     }
@@ -202,7 +202,7 @@ class ConsoleIO extends BaseIO
     /**
      * @inheritDoc
      */
-    public function overwriteError($messages, $newline = true, $size = null, $verbosity = self::NORMAL)
+    public function overwriteError($messages, $newline = true, $size = null, $verbosity = self::NORMAL): void
     {
         $this->doOverwrite($messages, $newline, $size, true, $verbosity);
     }
@@ -258,7 +258,7 @@ class ConsoleIO extends BaseIO
      * @param  int         $max
      * @return ProgressBar
      */
-    public function getProgressBar($max = 0)
+    public function getProgressBar($max = 0): \Symfony\Component\Console\Helper\ProgressBar
     {
         return new ProgressBar($this->getErrorOutput(), $max);
     }

--- a/src/Composer/InstalledVersions.php
+++ b/src/Composer/InstalledVersions.php
@@ -115,7 +115,7 @@ class InstalledVersions
      * @param  string|null   $constraint  A version constraint to check for, if you pass one you have to make sure composer/semver is required by your package
      * @return bool
      */
-    public static function satisfies(VersionParser $parser, $packageName, $constraint)
+    public static function satisfies(VersionParser $parser, $packageName, $constraint): bool
     {
         $constraint = $parser->parseConstraints($constraint);
         $provided = $parser->parseConstraints(self::getVersionRanges($packageName));
@@ -132,7 +132,7 @@ class InstalledVersions
      * @param  string $packageName
      * @return string Version constraint usable with composer/semver
      */
-    public static function getVersionRanges($packageName)
+    public static function getVersionRanges($packageName): string
     {
         foreach (self::getInstalled() as $installed) {
             if (!isset($installed['versions'][$packageName])) {
@@ -280,7 +280,7 @@ class InstalledVersions
      * @return array[]
      * @psalm-return list<array{root: array{name: string, version: string, reference: string, pretty_version: string, aliases: string[], dev: bool, install_path: string, type: string}, versions: array<string, array{dev_requirement: bool, pretty_version?: string, version?: string, aliases?: string[], reference?: string, replaced?: string[], provided?: string[], install_path?: string, type?: string}>}>
      */
-    public static function getAllRawData()
+    public static function getAllRawData(): array
     {
         return self::getInstalled();
     }
@@ -303,7 +303,7 @@ class InstalledVersions
      *
      * @psalm-param array{root: array{name: string, version: string, reference: string, pretty_version: string, aliases: string[], dev: bool, install_path: string, type: string}, versions: array<string, array{dev_requirement: bool, pretty_version?: string, version?: string, aliases?: string[], reference?: string, replaced?: string[], provided?: string[], install_path?: string, type?: string}>} $data
      */
-    public static function reload($data)
+    public static function reload($data): void
     {
         self::$installed = $data;
         self::$installedByVendor = array();

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -522,7 +522,7 @@ class Installer
             }
         }
 
-        $sortByName = function ($a, $b) {
+        $sortByName = function ($a, $b): int {
             if ($a instanceof UpdateOperation) {
                 $a = $a->getTargetPackage()->getName();
             } else {

--- a/src/Composer/Installer/InstallationManager.php
+++ b/src/Composer/Installer/InstallationManager.php
@@ -63,7 +63,7 @@ class InstallationManager
     /**
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->notifiablePackages = array();
         FileDownloader::$downloadMetadata = array();
@@ -76,7 +76,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function addInstaller(InstallerInterface $installer)
+    public function addInstaller(InstallerInterface $installer): void
     {
         array_unshift($this->installers, $installer);
         $this->cache = array();
@@ -89,7 +89,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function removeInstaller(InstallerInterface $installer)
+    public function removeInstaller(InstallerInterface $installer): void
     {
         if (false !== ($key = array_search($installer, $this->installers, true))) {
             array_splice($this->installers, $key, 1);
@@ -106,7 +106,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function disablePlugins()
+    public function disablePlugins(): void
     {
         foreach ($this->installers as $i => $installer) {
             if (!$installer instanceof PluginInstaller) {
@@ -167,7 +167,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function ensureBinariesPresence(PackageInterface $package)
+    public function ensureBinariesPresence(PackageInterface $package): void
     {
         try {
             $installer = $this->getInstaller($package->getType());
@@ -199,18 +199,18 @@ class InstallationManager
 
         $loop = $this->loop;
         $io = $this->io;
-        $runCleanup = function () use (&$cleanupPromises, $loop) {
+        $runCleanup = function () use (&$cleanupPromises, $loop): void {
             $promises = array();
 
             $loop->abortJobs();
 
             foreach ($cleanupPromises as $cleanup) {
-                $promises[] = new \React\Promise\Promise(function ($resolve, $reject) use ($cleanup) {
+                $promises[] = new \React\Promise\Promise(function ($resolve, $reject) use ($cleanup): void {
                     $promise = $cleanup();
                     if (!$promise instanceof PromiseInterface) {
                         $resolve();
                     } else {
-                        $promise->then(function () use ($resolve) {
+                        $promise->then(function () use ($resolve): void {
                             $resolve();
                         });
                     }
@@ -229,7 +229,7 @@ class InstallationManager
         if ($handleInterruptsUnix) {
             pcntl_async_signals(true);
             $prevHandler = pcntl_signal_get_handler(SIGINT);
-            pcntl_signal(SIGINT, function ($sig) use ($runCleanup, $prevHandler, $io) {
+            pcntl_signal(SIGINT, function ($sig) use ($runCleanup, $prevHandler, $io): void {
                 $io->writeError('Received SIGINT, aborting', true, IOInterface::DEBUG);
                 $runCleanup();
 
@@ -241,7 +241,7 @@ class InstallationManager
             });
         }
         if ($handleInterruptsWindows) {
-            $windowsHandler = function ($event) use ($runCleanup, $io) {
+            $windowsHandler = function ($event) use ($runCleanup, $io): void {
                 if ($event !== PHP_WINDOWS_EVENT_CTRL_C) {
                     return;
                 }
@@ -446,15 +446,15 @@ class InstallationManager
             $promise = $promise->then(function () use ($opType, $repo, $operation) {
                 return $this->$opType($repo, $operation);
             })->then($cleanupPromises[$index])
-            ->then(function () use ($devMode, $repo) {
+            ->then(function () use ($devMode, $repo): void {
                 $repo->write($devMode, $this);
-            }, function ($e) use ($opType, $package, $io) {
+            }, function ($e) use ($opType, $package, $io): void {
                 $io->writeError('    <error>' . ucfirst($opType) .' of '.$package->getPrettyName().' failed</error>');
 
                 throw $e;
             });
 
-            $postExecCallbacks[] = function () use ($opType, $runScripts, $dispatcher, $devMode, $repo, $allOperations, $operation) {
+            $postExecCallbacks[] = function () use ($opType, $runScripts, $dispatcher, $devMode, $repo, $allOperations, $operation): void {
                 $event = 'Composer\Installer\PackageEvents::POST_PACKAGE_'.strtoupper($opType);
                 if (defined($event) && $runScripts && $dispatcher) {
                     $dispatcher->dispatchPackageEvent(constant($event), $devMode, $repo, $allOperations, $operation);
@@ -548,7 +548,7 @@ class InstallationManager
             }
 
             $installer = $this->getInstaller($targetType);
-            $promise = $promise->then(function () use ($installer, $repo, $target) {
+            $promise = $promise->then(function () use ($installer, $repo, $target): ?\React\Promise\PromiseInterface {
                 return $installer->install($repo, $target);
             });
         }
@@ -564,7 +564,7 @@ class InstallationManager
      *
      * @return PromiseInterface|null
      */
-    public function uninstall(InstalledRepositoryInterface $repo, UninstallOperation $operation)
+    public function uninstall(InstalledRepositoryInterface $repo, UninstallOperation $operation): ?\React\Promise\PromiseInterface
     {
         $package = $operation->getPackage();
         $installer = $this->getInstaller($package->getType());
@@ -580,7 +580,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function markAliasInstalled(InstalledRepositoryInterface $repo, MarkAliasInstalledOperation $operation)
+    public function markAliasInstalled(InstalledRepositoryInterface $repo, MarkAliasInstalledOperation $operation): void
     {
         $package = $operation->getPackage();
 
@@ -597,7 +597,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function markAliasUninstalled(InstalledRepositoryInterface $repo, MarkAliasUninstalledOperation $operation)
+    public function markAliasUninstalled(InstalledRepositoryInterface $repo, MarkAliasUninstalledOperation $operation): void
     {
         $package = $operation->getPackage();
 
@@ -610,7 +610,7 @@ class InstallationManager
      * @param  PackageInterface $package
      * @return string           path
      */
-    public function getInstallPath(PackageInterface $package)
+    public function getInstallPath(PackageInterface $package): string
     {
         $installer = $this->getInstaller($package->getType());
 
@@ -622,7 +622,7 @@ class InstallationManager
      *
      * @return void
      */
-    public function setOutputProgress($outputProgress)
+    public function setOutputProgress($outputProgress): void
     {
         $this->outputProgress = $outputProgress;
     }
@@ -630,7 +630,7 @@ class InstallationManager
     /**
      * @return void
      */
-    public function notifyInstalls(IOInterface $io)
+    public function notifyInstalls(IOInterface $io): void
     {
         $promises = array();
 

--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -97,7 +97,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @inheritDoc
      */
-    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null): \React\Promise\PromiseInterface
     {
         $this->initializeVendorDir();
         $downloadPath = $this->getInstallPath($package);
@@ -108,7 +108,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @inheritDoc
      */
-    public function prepare($type, PackageInterface $package, PackageInterface $prevPackage = null)
+    public function prepare($type, PackageInterface $package, PackageInterface $prevPackage = null): ?\React\Promise\PromiseInterface
     {
         $this->initializeVendorDir();
         $downloadPath = $this->getInstallPath($package);
@@ -119,7 +119,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @inheritDoc
      */
-    public function cleanup($type, PackageInterface $package, PackageInterface $prevPackage = null)
+    public function cleanup($type, PackageInterface $package, PackageInterface $prevPackage = null): ?\React\Promise\PromiseInterface
     {
         $this->initializeVendorDir();
         $downloadPath = $this->getInstallPath($package);
@@ -148,7 +148,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         $binaryInstaller = $this->binaryInstaller;
         $installPath = $this->getInstallPath($package);
 
-        return $promise->then(function () use ($binaryInstaller, $installPath, $package, $repo) {
+        return $promise->then(function () use ($binaryInstaller, $installPath, $package, $repo): void {
             $binaryInstaller->installBinaries($package, $installPath);
             if (!$repo->hasPackage($package)) {
                 $repo->addPackage(clone $package);
@@ -176,7 +176,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         $binaryInstaller = $this->binaryInstaller;
         $installPath = $this->getInstallPath($target);
 
-        return $promise->then(function () use ($binaryInstaller, $installPath, $target, $initial, $repo) {
+        return $promise->then(function () use ($binaryInstaller, $installPath, $target, $initial, $repo): void {
             $binaryInstaller->installBinaries($target, $installPath);
             $repo->removePackage($initial);
             if (!$repo->hasPackage($target)) {
@@ -203,7 +203,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
         $downloadPath = $this->getPackageBasePath($package);
         $filesystem = $this->filesystem;
 
-        return $promise->then(function () use ($binaryInstaller, $filesystem, $downloadPath, $package, $repo) {
+        return $promise->then(function () use ($binaryInstaller, $filesystem, $downloadPath, $package, $repo): void {
             $binaryInstaller->removeBinaries($package);
             $repo->removePackage($package);
 
@@ -234,7 +234,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
      *
      * @param PackageInterface $package Package instance
      */
-    public function ensureBinariesPresence(PackageInterface $package)
+    public function ensureBinariesPresence(PackageInterface $package): void
     {
         $this->binaryInstaller->installBinaries($package, $this->getInstallPath($package), false);
     }
@@ -263,7 +263,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @return PromiseInterface|null
      */
-    protected function installCode(PackageInterface $package)
+    protected function installCode(PackageInterface $package): ?\React\Promise\PromiseInterface
     {
         $downloadPath = $this->getInstallPath($package);
 
@@ -288,7 +288,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
                     $promise = \React\Promise\resolve();
                 }
 
-                return $promise->then(function () use ($target) {
+                return $promise->then(function () use ($target): ?\React\Promise\PromiseInterface {
                     return $this->installCode($target);
                 });
             }
@@ -302,7 +302,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @return PromiseInterface|null
      */
-    protected function removeCode(PackageInterface $package)
+    protected function removeCode(PackageInterface $package): ?\React\Promise\PromiseInterface
     {
         $downloadPath = $this->getPackageBasePath($package);
 
@@ -312,7 +312,7 @@ class LibraryInstaller implements InstallerInterface, BinaryPresenceInterface
     /**
      * @return void
      */
-    protected function initializeVendorDir()
+    protected function initializeVendorDir(): void
     {
         $this->filesystem->ensureDirectoryExists($this->vendorDir);
         $this->vendorDir = realpath($this->vendorDir);

--- a/src/Composer/Installer/MetapackageInstaller.php
+++ b/src/Composer/Installer/MetapackageInstaller.php
@@ -45,7 +45,7 @@ class MetapackageInstaller implements InstallerInterface
     /**
      * @inheritDoc
      */
-    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package): bool
     {
         return $repo->hasPackage($package);
     }

--- a/src/Composer/Installer/NoopInstaller.php
+++ b/src/Composer/Installer/NoopInstaller.php
@@ -35,7 +35,7 @@ class NoopInstaller implements InstallerInterface
     /**
      * @inheritDoc
      */
-    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package): bool
     {
         return $repo->hasPackage($package);
     }

--- a/src/Composer/Installer/PluginInstaller.php
+++ b/src/Composer/Installer/PluginInstaller.php
@@ -46,7 +46,7 @@ class PluginInstaller extends LibraryInstaller
     /**
      * @inheritDoc
      */
-    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null): ?\React\Promise\PromiseInterface
     {
         $extra = $package->getExtra();
         if (empty($extra['class'])) {
@@ -66,7 +66,7 @@ class PluginInstaller extends LibraryInstaller
             $promise = \React\Promise\resolve();
         }
 
-        return $promise->then(function () use ($package, $repo) {
+        return $promise->then(function () use ($package, $repo): void {
             try {
                 Platform::workaroundFilesystemIssues();
                 $this->getPluginManager()->registerPackage($package, true);
@@ -86,7 +86,7 @@ class PluginInstaller extends LibraryInstaller
             $promise = \React\Promise\resolve();
         }
 
-        return $promise->then(function () use ($initial, $target, $repo) {
+        return $promise->then(function () use ($initial, $target, $repo): void {
             try {
                 Platform::workaroundFilesystemIssues();
                 $this->getPluginManager()->deactivatePackage($initial);
@@ -97,7 +97,7 @@ class PluginInstaller extends LibraryInstaller
         });
     }
 
-    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package): ?\React\Promise\PromiseInterface
     {
         $this->getPluginManager()->uninstallPackage($package);
 

--- a/src/Composer/Installer/SuggestedPackagesReporter.php
+++ b/src/Composer/Installer/SuggestedPackagesReporter.php
@@ -198,7 +198,7 @@ class SuggestedPackagesReporter
 
         $sourceFilter = array();
         if ($onlyDependentsOf) {
-            $sourceFilter = array_map(function ($link) {
+            $sourceFilter = array_map(function ($link): string {
                 return $link->getTarget();
             }, array_merge($onlyDependentsOf->getRequires(), $onlyDependentsOf->getDevRequires()));
             $sourceFilter[] = $onlyDependentsOf->getName();

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -79,7 +79,7 @@ class JsonFile
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return is_file($this->path);
     }

--- a/src/Composer/Json/JsonManipulator.php
+++ b/src/Composer/Json/JsonManipulator.php
@@ -94,7 +94,7 @@ class JsonManipulator
             // update existing link
             $existingPackage = $packageMatches['package'];
             $packageRegex = str_replace('/', '\\\\?/', preg_quote($existingPackage));
-            $links = Preg::replaceCallback('{'.self::$DEFINES.'"'.$packageRegex.'"(?P<separator>\s*:\s*)(?&string)}ix', function ($m) use ($existingPackage, $constraint) {
+            $links = Preg::replaceCallback('{'.self::$DEFINES.'"'.$packageRegex.'"(?P<separator>\s*:\s*)(?&string)}ix', function ($m) use ($existingPackage, $constraint): string {
                 return JsonFile::encode(str_replace('\\/', '/', $existingPackage)) . $m['separator'] . '"' . $constraint . '"';
             }, $links);
         } else {
@@ -135,7 +135,7 @@ class JsonManipulator
      */
     private function sortPackages(array &$packages = array()): void
     {
-        $prefix = function ($requirement) {
+        $prefix = function ($requirement): string {
             if (PlatformRepository::isPlatformPackage($requirement)) {
                 return Preg::replace(
                     array(
@@ -159,7 +159,7 @@ class JsonManipulator
             return '5-'.$requirement;
         };
 
-        uksort($packages, function ($a, $b) use ($prefix) {
+        uksort($packages, function ($a, $b) use ($prefix): int {
             return strnatcmp($prefix($a), $prefix($b));
         });
     }
@@ -170,7 +170,7 @@ class JsonManipulator
      * @param bool                  $append
      * @return bool
      */
-    public function addRepository($name, $config, $append = true)
+    public function addRepository($name, $config, $append = true): bool
     {
         return $this->addSubNode('repositories', $name, $config, $append);
     }
@@ -179,7 +179,7 @@ class JsonManipulator
      * @param string $name
      * @return bool
      */
-    public function removeRepository($name)
+    public function removeRepository($name): bool
     {
         return $this->removeSubNode('repositories', $name);
     }
@@ -189,7 +189,7 @@ class JsonManipulator
      * @param mixed  $value
      * @return bool
      */
-    public function addConfigSetting($name, $value)
+    public function addConfigSetting($name, $value): bool
     {
         return $this->addSubNode('config', $name, $value);
     }
@@ -198,7 +198,7 @@ class JsonManipulator
      * @param string $name
      * @return bool
      */
-    public function removeConfigSetting($name)
+    public function removeConfigSetting($name): bool
     {
         return $this->removeSubNode('config', $name);
     }
@@ -208,7 +208,7 @@ class JsonManipulator
      * @param mixed $value
      * @return bool
      */
-    public function addProperty($name, $value)
+    public function addProperty($name, $value): bool
     {
         if (strpos($name, 'suggest.') === 0) {
             return $this->addSubNode('suggest', substr($name, 8), $value);
@@ -229,7 +229,7 @@ class JsonManipulator
      * @param string $name
      * @return bool
      */
-    public function removeProperty($name)
+    public function removeProperty($name): bool
     {
         if (strpos($name, 'suggest.') === 0) {
             return $this->removeSubNode('suggest', substr($name, 8));
@@ -297,7 +297,7 @@ class JsonManipulator
         // child exists
         $childRegex = '{'.self::$DEFINES.'(?P<start>"'.preg_quote($name).'"\s*:\s*)(?P<content>(?&json))(?P<end>,?)}x';
         if (Preg::isMatch($childRegex, $children, $matches)) {
-            $children = Preg::replaceCallback($childRegex, function ($matches) use ($subName, $value) {
+            $children = Preg::replaceCallback($childRegex, function ($matches) use ($subName, $value): string {
                 if ($subName !== null) {
                     $curVal = json_decode($matches['content'], true);
                     if (!is_array($curVal)) {
@@ -351,7 +351,7 @@ class JsonManipulator
             }
         }
 
-        $this->contents = Preg::replaceCallback($nodeRegex, function ($m) use ($children) {
+        $this->contents = Preg::replaceCallback($nodeRegex, function ($m) use ($children): string {
             return $m['start'] . $children . $m['end'];
         }, $this->contents);
 
@@ -436,7 +436,7 @@ class JsonManipulator
             $newline = $this->newline;
             $indent = $this->indent;
 
-            $this->contents = Preg::replaceCallback($nodeRegex, function ($matches) use ($indent, $newline) {
+            $this->contents = Preg::replaceCallback($nodeRegex, function ($matches) use ($indent, $newline): string {
                 return $matches['start'] . '{' . $newline . $indent . '}' . $matches['end'];
             }, $this->contents);
 
@@ -450,7 +450,7 @@ class JsonManipulator
             return true;
         }
 
-        $this->contents = Preg::replaceCallback($nodeRegex, function ($matches) use ($name, $subName, $childrenClean) {
+        $this->contents = Preg::replaceCallback($nodeRegex, function ($matches) use ($name, $subName, $childrenClean): string {
             if ($subName !== null) {
                 $curVal = json_decode($matches['content'], true);
                 unset($curVal[$name][$subName]);
@@ -597,7 +597,7 @@ class JsonManipulator
     /**
      * @return void
      */
-    protected function detectIndenting()
+    protected function detectIndenting(): void
     {
         if (Preg::isMatch('{^([ \t]+)"}m', $this->contents, $match)) {
             $this->indent = $match[1];

--- a/src/Composer/Package/Archiver/ArchivableFilesFinder.php
+++ b/src/Composer/Package/Archiver/ArchivableFilesFinder.php
@@ -57,7 +57,7 @@ class ArchivableFilesFinder extends \FilterIterator
 
         $this->finder = new Finder();
 
-        $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs) {
+        $filter = function (\SplFileInfo $file) use ($sources, $filters, $fs): bool {
             if ($file->isLink() && strpos($file->getRealPath(), $sources) !== 0) {
                 return false;
             }

--- a/src/Composer/Package/Archiver/ArchiveManager.php
+++ b/src/Composer/Package/Archiver/ArchiveManager.php
@@ -101,7 +101,7 @@ class ArchiveManager
             $nameParts[] = substr(sha1($package->getSourceReference()), 0, 6);
         }
 
-        $name = implode('-', array_filter($nameParts, function ($p) {
+        $name = implode('-', array_filter($nameParts, function ($p): bool {
             return !empty($p);
         }));
 

--- a/src/Composer/Package/Archiver/BaseExcludeFilter.php
+++ b/src/Composer/Package/Archiver/BaseExcludeFilter.php
@@ -95,7 +95,7 @@ abstract class BaseExcludeFilter
                 },
                 $lines
             ),
-            function ($pattern) {
+            function ($pattern): bool {
                 return $pattern !== null;
             }
         );

--- a/src/Composer/Package/BasePackage.php
+++ b/src/Composer/Package/BasePackage.php
@@ -94,7 +94,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function getNames($provides = true)
+    public function getNames($provides = true): array
     {
         $names = array(
             $this->getName() => true,
@@ -116,7 +116,7 @@ abstract class BasePackage implements PackageInterface
     /**
      * @inheritDoc
      */
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -257,7 +257,7 @@ abstract class BasePackage implements PackageInterface
      * @param  non-empty-string $wrap         Wrap the cleaned string by the given string
      * @return non-empty-string
      */
-    public static function packageNameToRegexp($allowPattern, $wrap = '{^%s$}i')
+    public static function packageNameToRegexp($allowPattern, $wrap = '{^%s$}i'): string
     {
         $cleanedAllowPattern = str_replace('\\*', '.*', preg_quote($allowPattern));
 
@@ -271,10 +271,10 @@ abstract class BasePackage implements PackageInterface
      * @param non-empty-string $wrap
      * @return non-empty-string
      */
-    public static function packageNamesToRegexp(array $packageNames, $wrap = '{^(?:%s)$}iD')
+    public static function packageNamesToRegexp(array $packageNames, $wrap = '{^(?:%s)$}iD'): string
     {
         $packageNames = array_map(
-            function ($packageName) {
+            function ($packageName): string {
                 return BasePackage::packageNameToRegexp($packageName, '%s');
             },
             $packageNames

--- a/src/Composer/Package/CompletePackage.php
+++ b/src/Composer/Package/CompletePackage.php
@@ -47,7 +47,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setScripts(array $scripts)
+    public function setScripts(array $scripts): void
     {
         $this->scripts = $scripts;
     }
@@ -63,7 +63,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setRepositories(array $repositories)
+    public function setRepositories(array $repositories): void
     {
         $this->repositories = $repositories;
     }
@@ -79,7 +79,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setLicense(array $license)
+    public function setLicense(array $license): void
     {
         $this->license = $license;
     }
@@ -95,7 +95,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setKeywords(array $keywords)
+    public function setKeywords(array $keywords): void
     {
         $this->keywords = $keywords;
     }
@@ -111,7 +111,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setAuthors(array $authors)
+    public function setAuthors(array $authors): void
     {
         $this->authors = $authors;
     }
@@ -127,7 +127,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -143,7 +143,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setHomepage($homepage)
+    public function setHomepage($homepage): void
     {
         $this->homepage = $homepage;
     }
@@ -159,7 +159,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setSupport(array $support)
+    public function setSupport(array $support): void
     {
         $this->support = $support;
     }
@@ -175,7 +175,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setFunding(array $funding)
+    public function setFunding(array $funding): void
     {
         $this->funding = $funding;
     }
@@ -199,7 +199,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setAbandoned($abandoned)
+    public function setAbandoned($abandoned): void
     {
         $this->abandoned = $abandoned;
     }
@@ -215,7 +215,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setArchiveName($name)
+    public function setArchiveName($name): void
     {
         $this->archiveName = $name;
     }
@@ -231,7 +231,7 @@ class CompletePackage extends Package implements CompletePackageInterface
     /**
      * @inheritDoc
      */
-    public function setArchiveExcludes(array $excludes)
+    public function setArchiveExcludes(array $excludes): void
     {
         $this->archiveExcludes = $excludes;
     }

--- a/src/Composer/Package/Locker.php
+++ b/src/Composer/Package/Locker.php
@@ -357,7 +357,7 @@ class Locker
     {
         // keep old default branch names normalized to DEFAULT_BRANCH_ALIAS for BC as that is how Composer 1 outputs the lock file
         // when loading the lock file the version is anyway ignored in Composer 2, so it has no adverse effect
-        $aliases = array_map(function ($alias) {
+        $aliases = array_map(function ($alias): array {
             if (in_array($alias['version'], array('dev-master', 'dev-trunk', 'dev-default'), true)) {
                 $alias['version'] = VersionParser::DEFAULT_BRANCH_ALIAS;
             }

--- a/src/Composer/Package/Package.php
+++ b/src/Composer/Package/Package.php
@@ -130,7 +130,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }
@@ -156,7 +156,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setTargetDir($targetDir)
+    public function setTargetDir($targetDir): void
     {
         $this->targetDir = $targetDir;
     }
@@ -178,7 +178,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setExtra(array $extra)
+    public function setExtra(array $extra): void
     {
         $this->extra = $extra;
     }
@@ -196,7 +196,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setBinaries(array $binaries)
+    public function setBinaries(array $binaries): void
     {
         $this->binaries = $binaries;
     }
@@ -214,7 +214,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setInstallationSource($type)
+    public function setInstallationSource($type): void
     {
         $this->installationSource = $type;
     }
@@ -232,7 +232,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setSourceType($type)
+    public function setSourceType($type): void
     {
         $this->sourceType = $type;
     }
@@ -250,7 +250,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setSourceUrl($url)
+    public function setSourceUrl($url): void
     {
         $this->sourceUrl = $url;
     }
@@ -268,7 +268,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setSourceReference($reference)
+    public function setSourceReference($reference): void
     {
         $this->sourceReference = $reference;
     }
@@ -286,7 +286,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setSourceMirrors($mirrors)
+    public function setSourceMirrors($mirrors): void
     {
         $this->sourceMirrors = $mirrors;
     }
@@ -302,7 +302,7 @@ class Package extends BasePackage
     /**
      * @inheritDoc
      */
-    public function getSourceUrls()
+    public function getSourceUrls(): array
     {
         return $this->getUrls($this->sourceUrl, $this->sourceMirrors, $this->sourceReference, $this->sourceType, 'source');
     }
@@ -312,7 +312,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDistType($type)
+    public function setDistType($type): void
     {
         $this->distType = $type;
     }
@@ -330,7 +330,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDistUrl($url)
+    public function setDistUrl($url): void
     {
         $this->distUrl = $url;
     }
@@ -348,7 +348,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDistReference($reference)
+    public function setDistReference($reference): void
     {
         $this->distReference = $reference;
     }
@@ -366,7 +366,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDistSha1Checksum($sha1checksum)
+    public function setDistSha1Checksum($sha1checksum): void
     {
         $this->distSha1Checksum = $sha1checksum;
     }
@@ -384,7 +384,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDistMirrors($mirrors)
+    public function setDistMirrors($mirrors): void
     {
         $this->distMirrors = $mirrors;
     }
@@ -400,7 +400,7 @@ class Package extends BasePackage
     /**
      * @inheritDoc
      */
-    public function getDistUrls()
+    public function getDistUrls(): array
     {
         return $this->getUrls($this->distUrl, $this->distMirrors, $this->distReference, $this->distType, 'dist');
     }
@@ -416,7 +416,7 @@ class Package extends BasePackage
     /**
      * @inheritDoc
      */
-    public function setTransportOptions(array $options)
+    public function setTransportOptions(array $options): void
     {
         $this->transportOptions = $options;
     }
@@ -444,7 +444,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setReleaseDate(\DateTime $releaseDate)
+    public function setReleaseDate(\DateTime $releaseDate): void
     {
         $this->releaseDate = $releaseDate;
     }
@@ -464,7 +464,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setRequires(array $requires)
+    public function setRequires(array $requires): void
     {
         if (isset($requires[0])) { // @phpstan-ignore-line
             $requires = $this->convertLinksToMap($requires, 'setRequires');
@@ -488,7 +488,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setConflicts(array $conflicts)
+    public function setConflicts(array $conflicts): void
     {
         if (isset($conflicts[0])) { // @phpstan-ignore-line
             $conflicts = $this->convertLinksToMap($conflicts, 'setConflicts');
@@ -513,7 +513,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setProvides(array $provides)
+    public function setProvides(array $provides): void
     {
         if (isset($provides[0])) { // @phpstan-ignore-line
             $provides = $this->convertLinksToMap($provides, 'setProvides');
@@ -538,7 +538,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setReplaces(array $replaces)
+    public function setReplaces(array $replaces): void
     {
         if (isset($replaces[0])) { // @phpstan-ignore-line
             $replaces = $this->convertLinksToMap($replaces, 'setReplaces');
@@ -563,7 +563,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setDevRequires(array $devRequires)
+    public function setDevRequires(array $devRequires): void
     {
         if (isset($devRequires[0])) { // @phpstan-ignore-line
             $devRequires = $this->convertLinksToMap($devRequires, 'setDevRequires');
@@ -587,7 +587,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setSuggests(array $suggests)
+    public function setSuggests(array $suggests): void
     {
         $this->suggests = $suggests;
     }
@@ -609,7 +609,7 @@ class Package extends BasePackage
      *
      * @phpstan-param AutoloadRules $autoload
      */
-    public function setAutoload(array $autoload)
+    public function setAutoload(array $autoload): void
     {
         $this->autoload = $autoload;
     }
@@ -631,7 +631,7 @@ class Package extends BasePackage
      *
      * @phpstan-param DevAutoloadRules $devAutoload
      */
-    public function setDevAutoload(array $devAutoload)
+    public function setDevAutoload(array $devAutoload): void
     {
         $this->devAutoload = $devAutoload;
     }
@@ -651,7 +651,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setIncludePaths(array $includePaths)
+    public function setIncludePaths(array $includePaths): void
     {
         $this->includePaths = $includePaths;
     }
@@ -671,7 +671,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setNotificationUrl($notificationUrl)
+    public function setNotificationUrl($notificationUrl): void
     {
         $this->notificationUrl = $notificationUrl;
     }
@@ -689,7 +689,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function setIsDefaultBranch($defaultBranch)
+    public function setIsDefaultBranch($defaultBranch): void
     {
         $this->isDefaultBranch = $defaultBranch;
     }
@@ -705,7 +705,7 @@ class Package extends BasePackage
     /**
      * @inheritDoc
      */
-    public function setSourceDistReferences($reference)
+    public function setSourceDistReferences($reference): void
     {
         $this->setSourceReference($reference);
 
@@ -731,7 +731,7 @@ class Package extends BasePackage
      *
      * @return void
      */
-    public function replaceVersion($version, $prettyVersion)
+    public function replaceVersion($version, $prettyVersion): void
     {
         $this->version = $version;
         $this->prettyVersion = $prettyVersion;

--- a/src/Composer/Package/Version/VersionGuesser.php
+++ b/src/Composer/Package/Version/VersionGuesser.php
@@ -296,7 +296,7 @@ class VersionGuesser
             // sort local branches first then remote ones
             // and sort numeric branches below named ones, to make sure if the branch has the same distance from main and 1.10 and 1.9 for example, main is picked
             // and sort using natural sort so that 1.10 will appear before 1.9
-            usort($branches, function ($a, $b) {
+            usort($branches, function ($a, $b): int {
                 $aRemote = 0 === strpos($a, 'remotes/');
                 $bRemote = 0 === strpos($b, 'remotes/');
 

--- a/src/Composer/Package/Version/VersionSelector.php
+++ b/src/Composer/Package/Version/VersionSelector.php
@@ -87,7 +87,7 @@ class VersionSelector
 
         if ($this->platformConstraints && !($platformRequirementFilter instanceof IgnoreAllPlatformRequirementFilter)) {
             $platformConstraints = $this->platformConstraints;
-            $candidates = array_filter($candidates, function ($pkg) use ($platformConstraints, $platformRequirementFilter) {
+            $candidates = array_filter($candidates, function ($pkg) use ($platformConstraints, $platformRequirementFilter): bool {
                 $reqs = $pkg->getRequires();
 
                 foreach ($reqs as $name => $link) {

--- a/src/Composer/Question/StrictConfirmationQuestion.php
+++ b/src/Composer/Question/StrictConfirmationQuestion.php
@@ -86,7 +86,7 @@ class StrictConfirmationQuestion extends Question
      */
     private function getDefaultValidator(): callable
     {
-        return function ($answer) {
+        return function ($answer): bool {
             if (!is_bool($answer)) {
                 throw new InvalidArgumentException('Please answer yes, y, no, or n.');
             }

--- a/src/Composer/Repository/ArrayRepository.php
+++ b/src/Composer/Repository/ArrayRepository.php
@@ -146,7 +146,7 @@ class ArrayRepository implements RepositoryInterface
     /**
      * @inheritDoc
      */
-    public function search($query, $mode = 0, $type = null)
+    public function search($query, $mode = 0, $type = null): array
     {
         if ($mode === self::SEARCH_FULLTEXT) {
             $regex = '{(?:'.implode('|', Preg::split('{\s+}', preg_quote($query))).')}i';
@@ -266,7 +266,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return AliasPackage|CompleteAliasPackage
      */
-    protected function createAliasPackage(BasePackage $package, $alias, $prettyAlias)
+    protected function createAliasPackage(BasePackage $package, $alias, $prettyAlias): \Composer\Package\AliasPackage
     {
         while ($package instanceof AliasPackage) {
             $package = $package->getAliasOf();
@@ -286,7 +286,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return void
      */
-    public function removePackage(PackageInterface $package)
+    public function removePackage(PackageInterface $package): void
     {
         $packageId = $package->getUniqueName();
 
@@ -337,7 +337,7 @@ class ArrayRepository implements RepositoryInterface
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         $this->packages = array();
     }

--- a/src/Composer/Repository/ArtifactRepository.php
+++ b/src/Composer/Repository/ArtifactRepository.php
@@ -61,7 +61,7 @@ class ArtifactRepository extends ArrayRepository implements ConfigurableReposito
         return $this->repoConfig;
     }
 
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 

--- a/src/Composer/Repository/ComposerRepository.php
+++ b/src/Composer/Repository/ComposerRepository.php
@@ -302,7 +302,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         return $filteredPackages;
     }
 
-    public function getPackages()
+    public function getPackages(): array
     {
         $hasProviders = $this->hasProviders();
 
@@ -350,7 +350,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
              * @param list<string> $results
              * @return list<string>
              */
-            function (array $results) {
+            function (array $results): array {
                 return $results;
             }
         ;
@@ -361,7 +361,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
                  * @param list<string> $results
                  * @return list<string>
                  */
-                function (array $results) use ($packageFilterRegex) {
+                function (array $results) use ($packageFilterRegex): array {
                     /** @var list<string> $results */
                     return Preg::grep($packageFilterRegex, $results);
                 }
@@ -664,7 +664,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     /**
      * @return void
      */
-    protected function configurePackageTransportOptions(PackageInterface $package)
+    protected function configurePackageTransportOptions(PackageInterface $package): void
     {
         foreach ($package->getDistUrls() as $url) {
             if (strpos($url, $this->baseUrl) === 0) {
@@ -831,7 +831,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
     /**
      * @inheritDoc
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 
@@ -847,7 +847,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
      *
      * @param PackageInterface $package
      */
-    public function addPackage(PackageInterface $package)
+    public function addPackage(PackageInterface $package): void
     {
         parent::addPackage($package);
         $this->configurePackageTransportOptions($package);
@@ -905,7 +905,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             }
 
             $promises[] = $this->asyncFetchFile($url, $cacheKey, $lastModified)
-                ->then(function ($response) use (&$packages, &$namesFound, $url, $cacheKey, $contents, $realName, $constraint, $acceptableStabilities, $stabilityFlags, $alreadyLoaded) {
+                ->then(function ($response) use (&$packages, &$namesFound, $url, $cacheKey, $contents, $realName, $constraint, $acceptableStabilities, $stabilityFlags, $alreadyLoaded): void {
                     $packagesSource = 'downloaded file ('.Url::sanitize($url).')';
 
                     if (true === $response) {
@@ -1095,7 +1095,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
             // Disables lazy-provider behavior as with available-packages, but may allow much more compact expression of packages covered by this repository.
             // Over-specifying covered packages is safe, but may result in increased traffic to your repository.
             if (!empty($data['available-package-patterns'])) {
-                $this->availablePackagePatterns = array_map(function ($pattern) {
+                $this->availablePackagePatterns = array_map(function ($pattern): string {
                     return BasePackage::packageNameToRegexp($pattern);
                 }, $data['available-package-patterns']);
                 $this->hasAvailablePackageList = true;
@@ -1493,7 +1493,7 @@ class ComposerRepository extends ArrayRepository implements ConfigurableReposito
         $degradedMode = &$this->degradedMode;
         $eventDispatcher = $this->eventDispatcher;
 
-        $accept = function ($response) use ($io, $url, $filename, $cache, $cacheKey, $eventDispatcher) {
+        $accept = function ($response) use ($io, $url, $filename, $cache, $cacheKey, $eventDispatcher): array {
             // package not found is acceptable for a v2 protocol repository
             if ($response->getStatusCode() === 404) {
                 $this->packagesNotFoundCache[$filename] = true;

--- a/src/Composer/Repository/CompositeRepository.php
+++ b/src/Composer/Repository/CompositeRepository.php
@@ -42,7 +42,7 @@ class CompositeRepository implements RepositoryInterface
 
     public function getRepoName(): string
     {
-        return 'composite repo ('.implode(', ', array_map(function ($repo) {
+        return 'composite repo ('.implode(', ', array_map(function ($repo): string {
             return $repo->getRepoName();
         }, $this->repositories)).')';
     }

--- a/src/Composer/Repository/FilesystemRepository.php
+++ b/src/Composer/Repository/FilesystemRepository.php
@@ -106,7 +106,7 @@ class FilesystemRepository extends WritableArrayRepository
         }
     }
 
-    public function reload()
+    public function reload(): void
     {
         $this->packages = null;
         $this->initialize();
@@ -150,7 +150,7 @@ class FilesystemRepository extends WritableArrayRepository
         }
 
         sort($data['dev-package-names']);
-        usort($data['packages'], function ($a, $b) {
+        usort($data['packages'], function ($a, $b): int {
             return strcmp($a['name'], $b['name']);
         });
 

--- a/src/Composer/Repository/InstalledRepository.php
+++ b/src/Composer/Repository/InstalledRepository.php
@@ -251,7 +251,7 @@ class InstalledRepository extends CompositeRepository
 
     public function getRepoName(): string
     {
-        return 'installed repo ('.implode(', ', array_map(function ($repo) {
+        return 'installed repo ('.implode(', ', array_map(function ($repo): string {
             return $repo->getRepoName();
         }, $this->getRepositories())).')';
     }

--- a/src/Composer/Repository/PathRepository.php
+++ b/src/Composer/Repository/PathRepository.php
@@ -251,7 +251,7 @@ class PathRepository extends ArrayRepository implements ConfigurableRepositoryIn
         }
 
         // Ensure environment-specific path separators are normalized to URL separators
-        return array_map(function ($val) {
+        return array_map(function ($val): string {
             return rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $val), '/');
         }, glob($this->url, $flags));
     }

--- a/src/Composer/Repository/PlatformRepository.php
+++ b/src/Composer/Repository/PlatformRepository.php
@@ -365,7 +365,7 @@ class PlatformRepository extends ArrayRepository
 
                 case 'libxml':
                     // ext/dom, ext/simplexml, ext/xmlreader and ext/xmlwriter use the same libxml as the ext/libxml
-                    $libxmlProvides = array_map(function ($extension) {
+                    $libxmlProvides = array_map(function ($extension): string {
                         return $extension . '-libxml';
                     }, array_intersect($loadedExtensions, array('dom', 'simplexml', 'xml', 'xmlreader', 'xmlwriter')));
                     $this->addLibrary($name, $this->runtime->getConstant('LIBXML_DOTTED_VERSION'), 'libxml library version', array(), $libxmlProvides);

--- a/src/Composer/Repository/RepositoryManager.php
+++ b/src/Composer/Repository/RepositoryManager.php
@@ -100,7 +100,7 @@ class RepositoryManager
      *
      * @return void
      */
-    public function addRepository(RepositoryInterface $repository)
+    public function addRepository(RepositoryInterface $repository): void
     {
         $this->repositories[] = $repository;
     }
@@ -114,7 +114,7 @@ class RepositoryManager
      *
      * @return void
      */
-    public function prependRepository(RepositoryInterface $repository)
+    public function prependRepository(RepositoryInterface $repository): void
     {
         array_unshift($this->repositories, $repository);
     }
@@ -162,7 +162,7 @@ class RepositoryManager
      *
      * @return void
      */
-    public function setRepositoryClass($type, $class)
+    public function setRepositoryClass($type, $class): void
     {
         $this->repositoryClasses[$type] = $class;
     }
@@ -184,7 +184,7 @@ class RepositoryManager
      *
      * @return void
      */
-    public function setLocalRepository(InstalledRepositoryInterface $repository)
+    public function setLocalRepository(InstalledRepositoryInterface $repository): void
     {
         $this->localRepository = $repository;
     }

--- a/src/Composer/Repository/Vcs/GitBitbucketDriver.php
+++ b/src/Composer/Repository/Vcs/GitBitbucketDriver.php
@@ -205,7 +205,7 @@ class GitBitbucketDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function getFileContent($file, $identifier)
+    public function getFileContent($file, $identifier): ?string
     {
         if ($this->fallbackDriver) {
             return $this->fallbackDriver->getFileContent($file, $identifier);
@@ -445,7 +445,7 @@ class GitBitbucketDriver extends VcsDriver
      * @param  string $url
      * @return void
      */
-    protected function setupFallbackDriver($url)
+    protected function setupFallbackDriver($url): void
     {
         $this->fallbackDriver = new GitDriver(
             array('url' => $url),
@@ -461,7 +461,7 @@ class GitBitbucketDriver extends VcsDriver
      * @param  array<array{name: string, href: string}> $cloneLinks
      * @return void
      */
-    protected function parseCloneUrls(array $cloneLinks)
+    protected function parseCloneUrls(array $cloneLinks): void
     {
         foreach ($cloneLinks as $cloneLink) {
             if ($cloneLink['name'] === 'https') {

--- a/src/Composer/Repository/Vcs/GitDriver.php
+++ b/src/Composer/Repository/Vcs/GitDriver.php
@@ -151,7 +151,7 @@ class GitDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function getChangeDate($identifier)
+    public function getChangeDate($identifier): \DateTime
     {
         $this->process->execute(sprintf(
             'git -c log.showSignature=false log -1 --format=%%at %s',
@@ -234,7 +234,7 @@ class GitDriver extends VcsDriver
         GitUtil::cleanEnv();
 
         try {
-            $gitUtil->runCommand(function ($url) {
+            $gitUtil->runCommand(function ($url): string {
                 return 'git ls-remote --heads -- ' . ProcessExecutor::escape($url);
             }, $url, sys_get_temp_dir());
         } catch (\RuntimeException $e) {

--- a/src/Composer/Repository/Vcs/GitHubDriver.php
+++ b/src/Composer/Repository/Vcs/GitHubDriver.php
@@ -588,7 +588,7 @@ class GitHubDriver extends VcsDriver
      *
      * @return void
      */
-    protected function setupGitDriver($url)
+    protected function setupGitDriver($url): void
     {
         $this->gitDriver = new GitDriver(
             array('url' => $url),

--- a/src/Composer/Repository/Vcs/HgDriver.php
+++ b/src/Composer/Repository/Vcs/HgDriver.php
@@ -71,7 +71,7 @@ class HgDriver extends VcsDriver
                 $fs->removeDirectory($this->repoDir);
 
                 $repoDir = $this->repoDir;
-                $command = function ($url) use ($repoDir) {
+                $command = function ($url) use ($repoDir): string {
                     return sprintf('hg clone --noupdate -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($repoDir));
                 };
 
@@ -139,7 +139,7 @@ class HgDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function getChangeDate($identifier)
+    public function getChangeDate($identifier): \DateTime
     {
         $this->process->execute(
             sprintf(

--- a/src/Composer/Repository/Vcs/PerforceDriver.php
+++ b/src/Composer/Repository/Vcs/PerforceDriver.php
@@ -34,7 +34,7 @@ class PerforceDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->depot = $this->repoConfig['depot'];
         $this->branch = '';
@@ -171,7 +171,7 @@ class PerforceDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->perforce->cleanupClientSpec();
         $this->perforce = null;

--- a/src/Composer/Repository/Vcs/SvnDriver.php
+++ b/src/Composer/Repository/Vcs/SvnDriver.php
@@ -57,7 +57,7 @@ class SvnDriver extends VcsDriver
     /**
      * @inheritDoc
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->url = $this->baseUrl = rtrim(self::normalizeUrl($this->url), '/');
 

--- a/src/Composer/Repository/Vcs/VcsDriver.php
+++ b/src/Composer/Repository/Vcs/VcsDriver.php
@@ -165,7 +165,7 @@ abstract class VcsDriver implements VcsDriverInterface
      * @return Response
      * @throws TransportException
      */
-    protected function getContents($url)
+    protected function getContents($url): \Composer\Util\Http\Response
     {
         $options = $this->repoConfig['options'] ?? array();
 
@@ -175,7 +175,7 @@ abstract class VcsDriver implements VcsDriverInterface
     /**
      * @inheritDoc
      */
-    public function cleanup()
+    public function cleanup(): void
     {
         return;
     }

--- a/src/Composer/Repository/VcsRepository.php
+++ b/src/Composer/Repository/VcsRepository.php
@@ -121,7 +121,7 @@ class VcsRepository extends ArrayRepository implements ConfigurableRepositoryInt
     /**
      * @return void
      */
-    public function setLoader(LoaderInterface $loader)
+    public function setLoader(LoaderInterface $loader): void
     {
         $this->loader = $loader;
     }

--- a/src/Composer/Repository/WritableArrayRepository.php
+++ b/src/Composer/Repository/WritableArrayRepository.php
@@ -42,7 +42,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function setDevPackageNames(array $devPackageNames)
+    public function setDevPackageNames(array $devPackageNames): void
     {
         $this->devPackageNames = $devPackageNames;
     }
@@ -58,7 +58,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function write($devMode, InstallationManager $installationManager)
+    public function write($devMode, InstallationManager $installationManager): void
     {
         $this->devMode = $devMode;
     }
@@ -66,7 +66,7 @@ class WritableArrayRepository extends ArrayRepository implements WritableReposit
     /**
      * @inheritDoc
      */
-    public function reload()
+    public function reload(): void
     {
         $this->devMode = null;
     }

--- a/src/Composer/Util/AuthHelper.php
+++ b/src/Composer/Util/AuthHelper.php
@@ -50,7 +50,7 @@ class AuthHelper
         } elseif ($storeAuth === 'prompt') {
             $answer = $this->io->askAndValidate(
                 'Do you want to store credentials for '.$origin.' in '.$configSource->getName().' ? [Yn] ',
-                function ($value) {
+                function ($value): string {
                     $input = strtolower(substr(trim($value), 0, 1));
                     if (in_array($input, array('y','n'))) {
                         return $input;

--- a/src/Composer/Util/ErrorHandler.php
+++ b/src/Composer/Util/ErrorHandler.php
@@ -56,7 +56,7 @@ class ErrorHandler
             self::$io->writeError('<warning>Deprecation Notice: '.$message.' in '.$file.':'.$line.'</warning>');
             if (self::$io->isVerbose()) {
                 self::$io->writeError('<warning>Stack trace:</warning>');
-                self::$io->writeError(array_filter(array_map(function ($a) {
+                self::$io->writeError(array_filter(array_map(function ($a): ?string {
                     if (isset($a['line'], $a['file'])) {
                         return '<warning> '.$a['file'].':'.$a['line'].'</warning>';
                     }

--- a/src/Composer/Util/Filesystem.php
+++ b/src/Composer/Util/Filesystem.php
@@ -74,7 +74,7 @@ class Filesystem
      *
      * @return void
      */
-    public function emptyDirectory($dir, $ensureDirectoryExists = true)
+    public function emptyDirectory($dir, $ensureDirectoryExists = true): void
     {
         if (is_link($dir) && file_exists($dir)) {
             $this->unlink($dir);
@@ -345,7 +345,7 @@ class Filesystem
      *
      * @return void
      */
-    public function copyThenRemove($source, $target)
+    public function copyThenRemove($source, $target): void
     {
         $this->copy($source, $target);
         if (!is_dir($source)) {
@@ -394,7 +394,7 @@ class Filesystem
      *
      * @return void
      */
-    public function rename($source, $target)
+    public function rename($source, $target): void
     {
         if (true === @rename($source, $target)) {
             return;
@@ -624,7 +624,7 @@ class Filesystem
      * @param  string $path
      * @return bool
      */
-    public static function isLocalPath($path)
+    public static function isLocalPath($path): bool
     {
         return Preg::isMatch('{^(file://(?!//)|/(?!/)|/?[a-z]:[\\\\/]|\.\.[\\\\/]|[a-z0-9_.-]+[\\\\/])}i', $path);
     }
@@ -905,7 +905,7 @@ class Filesystem
      *
      * @return void
      */
-    public function safeCopy($source, $target)
+    public function safeCopy($source, $target): void
     {
         if (!file_exists($target) || !file_exists($source) || !$this->filesAreEqual($source, $target)) {
             $source = fopen($source, 'r');

--- a/src/Composer/Util/Git.php
+++ b/src/Composer/Util/Git.php
@@ -283,7 +283,7 @@ class Git
         // update the repo if it is a valid git repository
         if (is_dir($dir) && 0 === $this->process->execute('git rev-parse --git-dir', $output, $dir) && trim($output) === '.') {
             try {
-                $commandCallable = function ($url) {
+                $commandCallable = function ($url): string {
                     $sanitizedUrl = Preg::replace('{://([^@]+?):(.+?)@}', '://', $url);
 
                     return sprintf('git remote set-url origin -- %s && git remote update --prune origin && git remote set-url origin -- %s && git gc --auto', ProcessExecutor::escape($url), ProcessExecutor::escape($sanitizedUrl));
@@ -301,7 +301,7 @@ class Git
         // clean up directory and do a fresh clone into it
         $this->filesystem->removeDirectory($dir);
 
-        $commandCallable = function ($url) use ($dir) {
+        $commandCallable = function ($url) use ($dir): string {
             return sprintf('git clone --mirror -- %s %s', ProcessExecutor::escape($url), ProcessExecutor::escape($dir));
         };
 
@@ -395,7 +395,7 @@ class Git
     /**
      * @return void
      */
-    public static function cleanEnv()
+    public static function cleanEnv(): void
     {
         // added in git 1.7.1, prevents prompting the user for username/password
         if (Platform::getEnv('GIT_ASKPASS') !== 'echo') {

--- a/src/Composer/Util/HttpDownloader.php
+++ b/src/Composer/Util/HttpDownloader.php
@@ -139,7 +139,7 @@ class HttpDownloader
      * @throws TransportException
      * @return Response
      */
-    public function copy($url, $to, $options = array())
+    public function copy($url, $to, $options = array()): \Composer\Util\Http\Response
     {
         list($job) = $this->addJob(array('url' => $url, 'options' => $options, 'copyTo' => $to), true);
         $this->wait($job['id']);
@@ -180,7 +180,7 @@ class HttpDownloader
      * @param  mixed[] $options
      * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = array_replace_recursive($this->options, $options);
     }
@@ -216,13 +216,13 @@ class HttpDownloader
         $rfs = $this->rfs;
 
         if ($this->canUseCurl($job)) {
-            $resolver = function ($resolve, $reject) use (&$job) {
+            $resolver = function ($resolve, $reject) use (&$job): void {
                 $job['status'] = HttpDownloader::STATUS_QUEUED;
                 $job['resolve'] = $resolve;
                 $job['reject'] = $reject;
             };
         } else {
-            $resolver = function ($resolve, $reject) use (&$job, $rfs) {
+            $resolver = function ($resolve, $reject) use (&$job, $rfs): void {
                 // start job
                 $url = $job['request']['url'];
                 $options = $job['request']['options'];
@@ -248,7 +248,7 @@ class HttpDownloader
 
         $curl = $this->curl;
 
-        $canceler = function () use (&$job, $curl) {
+        $canceler = function () use (&$job, $curl): void {
             if ($job['status'] === HttpDownloader::STATUS_QUEUED) {
                 $job['status'] = HttpDownloader::STATUS_ABORTED;
             }
@@ -270,7 +270,7 @@ class HttpDownloader
             $this->markJobDone();
 
             return $response;
-        }, function ($e) use (&$job) {
+        }, function ($e) use (&$job): void {
             $job['status'] = HttpDownloader::STATUS_FAILED;
             $job['exception'] = $e;
 
@@ -343,7 +343,7 @@ class HttpDownloader
      *
      * @return void
      */
-    public function wait($index = null)
+    public function wait($index = null): void
     {
         do {
             $jobCount = $this->countActiveJobs($index);

--- a/src/Composer/Util/Perforce.php
+++ b/src/Composer/Util/Perforce.php
@@ -85,7 +85,7 @@ class Perforce
      *
      * @return self
      */
-    public static function create($repoConfig, $port, $path, ProcessExecutor $process, IOInterface $io)
+    public static function create($repoConfig, $port, $path, ProcessExecutor $process, IOInterface $io): \Composer\Util\Perforce
     {
         return new Perforce($repoConfig, $port, $path, $process, Platform::isWindows(), $io);
     }
@@ -106,7 +106,7 @@ class Perforce
      *
      * @return void
      */
-    public function initialize($repoConfig)
+    public function initialize($repoConfig): void
     {
         $this->uniquePerforceClientName = $this->generateUniquePerforceClientName();
         if (!$repoConfig) {
@@ -138,7 +138,7 @@ class Perforce
      *
      * @return void
      */
-    public function initializeDepotAndBranch($depot, $branch)
+    public function initializeDepotAndBranch($depot, $branch): void
     {
         if (isset($depot)) {
             $this->p4Depot = $depot;
@@ -159,7 +159,7 @@ class Perforce
     /**
      * @return void
      */
-    public function cleanupClientSpec()
+    public function cleanupClientSpec(): void
     {
         $client = $this->getClient();
         $task = 'client -d ' . ProcessExecutor::escape($client);
@@ -176,7 +176,7 @@ class Perforce
      *
      * @return int
      */
-    protected function executeCommand($command)
+    protected function executeCommand($command): int
     {
         $this->commandResult = '';
 
@@ -209,7 +209,7 @@ class Perforce
      *
      * @return void
      */
-    public function initializePath($path)
+    public function initializePath($path): void
     {
         $this->path = $path;
         $fs = $this->getFilesystem();
@@ -229,7 +229,7 @@ class Perforce
      *
      * @return void
      */
-    public function setStream($stream)
+    public function setStream($stream): void
     {
         $this->p4Stream = $stream;
         $index = strrpos($stream, '/');
@@ -299,7 +299,7 @@ class Perforce
      *
      * @return void
      */
-    public function setUser($user)
+    public function setUser($user): void
     {
         $this->p4User = $user;
     }
@@ -307,7 +307,7 @@ class Perforce
     /**
      * @return void
      */
-    public function queryP4User()
+    public function queryP4User(): void
     {
         $this->getUser();
         if (strlen((string) $this->p4User) > 0) {
@@ -423,7 +423,7 @@ class Perforce
     /**
      * @return void
      */
-    public function connectClient()
+    public function connectClient(): void
     {
         $p4CreateClientCommand = $this->generateP4Command(
             'client -i < ' . str_replace(" ", "\\ ", $this->getP4ClientSpec())
@@ -436,7 +436,7 @@ class Perforce
      *
      * @return void
      */
-    public function syncCodeBase($sourceReference)
+    public function syncCodeBase($sourceReference): void
     {
         $prevDir = getcwd();
         chdir($this->path);
@@ -453,7 +453,7 @@ class Perforce
      *
      * @return void
      */
-    public function writeClientSpecToFile($spec)
+    public function writeClientSpecToFile($spec): void
     {
         fwrite($spec, 'Client: ' . $this->getClient() . PHP_EOL . PHP_EOL);
         fwrite($spec, 'Update: ' . date('Y/m/d H:i:s') . PHP_EOL . PHP_EOL);
@@ -498,7 +498,7 @@ class Perforce
      *
      * @return void
      */
-    protected function read($pipe, $name)
+    protected function read($pipe, $name): void
     {
         if (feof($pipe)) {
             return;
@@ -514,7 +514,7 @@ class Perforce
      *
      * @return int
      */
-    public function windowsLogin($password)
+    public function windowsLogin($password): int
     {
         $command = $this->generateP4Command(' login -a');
 
@@ -746,7 +746,7 @@ class Perforce
     /**
      * @return void
      */
-    public function setFilesystem(Filesystem $fs)
+    public function setFilesystem(Filesystem $fs): void
     {
         $this->filesystem = $fs;
     }

--- a/src/Composer/Util/Platform.php
+++ b/src/Composer/Util/Platform.php
@@ -82,7 +82,7 @@ class Platform
             return self::getUserDirectory() . substr($path, 1);
         }
 
-        return Preg::replaceCallback('#^(\$|(?P<percent>%))(?P<var>\w++)(?(percent)%)(?P<path>.*)#', function ($matches) {
+        return Preg::replaceCallback('#^(\$|(?P<percent>%))(?P<var>\w++)(?(percent)%)(?P<path>.*)#', function ($matches): string {
             // Treat HOME as an alias for USERPROFILE on Windows for legacy reasons
             if (Platform::isWindows() && $matches['var'] == 'HOME') {
                 return (Platform::getEnv('HOME') ?: Platform::getEnv('USERPROFILE')) . $matches['path'];

--- a/src/Composer/Util/ProcessExecutor.php
+++ b/src/Composer/Util/ProcessExecutor.php
@@ -68,7 +68,7 @@ class ProcessExecutor
      * @param  ?string $cwd     the working directory
      * @return int     statuscode
      */
-    public function execute($command, &$output = null, $cwd = null)
+    public function execute($command, &$output = null, $cwd = null): int
     {
         if (func_num_args() > 1) {
             return $this->doExecute($command, $cwd, false, $output);
@@ -84,7 +84,7 @@ class ProcessExecutor
      * @param  ?string $cwd     the working directory
      * @return int     statuscode
      */
-    public function executeTty($command, $cwd = null)
+    public function executeTty($command, $cwd = null): int
     {
         if (Platform::isTty()) {
             return $this->doExecute($command, $cwd, true);
@@ -153,13 +153,13 @@ class ProcessExecutor
             'cwd' => $cwd,
         );
 
-        $resolver = function ($resolve, $reject) use (&$job) {
+        $resolver = function ($resolve, $reject) use (&$job): void {
             $job['status'] = ProcessExecutor::STATUS_QUEUED;
             $job['resolve'] = $resolve;
             $job['reject'] = $reject;
         };
 
-        $canceler = function () use (&$job) {
+        $canceler = function () use (&$job): void {
             if ($job['status'] === ProcessExecutor::STATUS_QUEUED) {
                 $job['status'] = ProcessExecutor::STATUS_ABORTED;
             }
@@ -190,7 +190,7 @@ class ProcessExecutor
             $this->markJobDone();
 
             return $job['process'];
-        }, function ($e) use (&$job) {
+        }, function ($e) use (&$job): void {
             $job['status'] = ProcessExecutor::STATUS_FAILED;
 
             $this->markJobDone();
@@ -253,7 +253,7 @@ class ProcessExecutor
      * @param  ?int $index job id
      * @return void
      */
-    public function wait($index = null)
+    public function wait($index = null): void
     {
         while (true) {
             if (!$this->countActiveJobs($index)) {
@@ -349,7 +349,7 @@ class ProcessExecutor
      *
      * @return void
      */
-    public function outputHandler($type, $buffer)
+    public function outputHandler($type, $buffer): void
     {
         if ($this->captureOutput) {
             return;
@@ -380,7 +380,7 @@ class ProcessExecutor
      * @param  int  $timeout the timeout in seconds
      * @return void
      */
-    public static function setTimeout($timeout)
+    public static function setTimeout($timeout): void
     {
         static::$timeout = $timeout;
     }
@@ -392,7 +392,7 @@ class ProcessExecutor
      *
      * @return string The escaped argument
      */
-    public static function escape($argument)
+    public static function escape($argument): string
     {
         return self::escapeArgument($argument);
     }
@@ -407,7 +407,7 @@ class ProcessExecutor
         }
 
         $commandString = is_string($command) ? $command : implode(' ', array_map(self::class.'::escape', $command));
-        $safeCommand = Preg::replaceCallback('{://(?P<user>[^:/\s]+):(?P<password>[^@\s/]+)@}i', function ($m) {
+        $safeCommand = Preg::replaceCallback('{://(?P<user>[^:/\s]+):(?P<password>[^@\s/]+)@}i', function ($m): string {
             // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx) we obfuscate that
             if (Preg::isMatch('{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+)$}', $m['user'])) {
                 return '://***:***@';

--- a/src/Composer/Util/RemoteFilesystem.php
+++ b/src/Composer/Util/RemoteFilesystem.php
@@ -290,7 +290,7 @@ class RemoteFilesystem
         $errorMessage = '';
         $errorCode = 0;
         $result = false;
-        set_error_handler(function ($code, $msg) use (&$errorMessage) {
+        set_error_handler(function ($code, $msg) use (&$errorMessage): bool {
             if ($errorMessage) {
                 $errorMessage .= "\n";
             }
@@ -445,7 +445,7 @@ class RemoteFilesystem
             }
 
             $errorMessage = '';
-            set_error_handler(function ($code, $msg) use (&$errorMessage) {
+            set_error_handler(function ($code, $msg) use (&$errorMessage): bool {
                 if ($errorMessage) {
                     $errorMessage .= "\n";
                 }

--- a/src/Composer/Util/StreamContextFactory.php
+++ b/src/Composer/Util/StreamContextFactory.php
@@ -245,7 +245,7 @@ final class StreamContextFactory
         if (!is_array($header)) {
             $header = explode("\r\n", $header);
         }
-        uasort($header, function ($el) {
+        uasort($header, function ($el): int {
             return stripos($el, 'content-type') === 0 ? 1 : -1;
         });
 

--- a/src/Composer/Util/TlsHelper.php
+++ b/src/Composer/Util/TlsHelper.php
@@ -78,7 +78,7 @@ final class TlsHelper
 
         if (isset($info['extensions']['subjectAltName'])) {
             $subjectAltNames = Preg::split('{\s*,\s*}', $info['extensions']['subjectAltName']);
-            $subjectAltNames = array_filter(array_map(function ($name) {
+            $subjectAltNames = array_filter(array_map(function ($name): ?string {
                 if (0 === strpos($name, 'DNS:')) {
                     return strtolower(ltrim(substr($name, 4)));
                 }
@@ -179,7 +179,7 @@ final class TlsHelper
 
         if (0 === $wildcards) {
             // Literal match.
-            return function ($hostname) use ($certName) {
+            return function ($hostname) use ($certName): bool {
                 return $hostname === $certName;
             };
         }
@@ -203,7 +203,7 @@ final class TlsHelper
             $wildcardRegex = str_replace('\\*', '[a-z0-9-]+', $wildcardRegex);
             $wildcardRegex = "{^{$wildcardRegex}$}";
 
-            return function ($hostname) use ($wildcardRegex) {
+            return function ($hostname) use ($wildcardRegex): bool {
                 return Preg::isMatch($wildcardRegex, $hostname);
             };
         }

--- a/src/Composer/Util/Url.php
+++ b/src/Composer/Util/Url.php
@@ -114,7 +114,7 @@ class Url
         // e.g. https://api.github.com/repositories/9999999999?access_token=github_token
         $url = Preg::replace('{([&?]access_token=)[^&]+}', '$1***', $url);
 
-        $url = Preg::replaceCallback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+):(?P<password>[^@\s/]+)@}i', function ($m) {
+        $url = Preg::replaceCallback('{^(?P<prefix>[a-z0-9]+://)?(?P<user>[^:/\s@]+):(?P<password>[^@\s/]+)@}i', function ($m): string {
             // if the username looks like a long (12char+) hex string, or a modern github token (e.g. ghp_xxx) we obfuscate that
             if (Preg::isMatch('{^([a-f0-9]{12,}|gh[a-z]_[a-zA-Z0-9_]+)$}', $m['user'])) {
                 return $m['prefix'].'***:***@';


### PR DESCRIPTION
Rector test run.

It currently breaks the tests / composer, because some Implementation not longer match there Interface. Think this is because of https://www.php.net/manual/en/language.oop5.variance.php which is not supported well on 7.2 / 7.3 and this return types would in that case be needed to be adjusted in the interface or changed back in the implementation.